### PR TITLE
Chunk E: signal types, extractor, combiner (shadow mode)

### DIFF
--- a/parapet/src/eval/mod.rs
+++ b/parapet/src/eval/mod.rs
@@ -23,6 +23,8 @@ use crate::engine::{
     DefaultProviderRegistry, EngineDeps, EngineUpstreamClient, HttpBody, HttpError, HttpRequest,
     HttpResponse, HttpSender, UpstreamResolver,
 };
+use crate::signal::combiner::DefaultVerdictCombiner;
+use crate::signal::extractor::DefaultSignalExtractor;
 use crate::layers::l1::{DefaultL1Scanner, L1Scanner};
 use crate::layers::l3_inbound::DefaultInboundScanner;
 use crate::layers::l4::{DefaultMultiTurnScanner, MultiTurnScanner};
@@ -297,6 +299,8 @@ pub fn build_eval_engine(config: Arc<Config>) -> (EngineUpstreamClient, Arc<Mock
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner,
+        signal_extractor: Arc::new(DefaultSignalExtractor),
+        verdict_combiner: Arc::new(DefaultVerdictCombiner),
     };
 
     (EngineUpstreamClient::new_with(deps), mock)

--- a/parapet/src/lib.rs
+++ b/parapet/src/lib.rs
@@ -11,5 +11,6 @@ pub mod normalize;
 pub mod provider;
 pub mod proxy;
 pub mod session;
+pub mod signal;
 pub(crate) mod stream;
 pub mod trust;

--- a/parapet/src/signal/combiner.rs
+++ b/parapet/src/signal/combiner.rs
@@ -1,0 +1,299 @@
+// Copyright 2026 The Parapet Project
+// SPDX-License-Identifier: Apache-2.0
+
+// Verdict combiner — combines signals into a composite verdict.
+
+use std::collections::HashSet;
+
+use super::{LayerId, Signal, SignalContribution, SignalKind, Verdict, VerdictAction};
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// Combines signals into a composite verdict.
+///
+/// Returns the **recommended** action — the engine decides whether to enforce
+/// (shadow logs it, hybrid enforces it).
+pub trait VerdictCombiner: Send + Sync {
+    fn combine(&self, signals: &[Signal]) -> Verdict;
+}
+
+// ---------------------------------------------------------------------------
+// Default implementation
+// ---------------------------------------------------------------------------
+
+/// SIEM-style combiner: max baseline + cross-layer boost + multiplicative dampener.
+pub struct DefaultVerdictCombiner;
+
+impl DefaultVerdictCombiner {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Threshold above which the combiner recommends Block.
+const BLOCK_THRESHOLD: f32 = 0.5;
+
+/// Cross-layer boost factor when 2+ layers agree.
+const BOOST_FACTOR: f32 = 0.2;
+
+/// Minimum signal score to count as "agreeing" for cross-layer boost.
+const AGREEMENT_THRESHOLD: f32 = 0.3;
+
+/// L1 score below which the dampener activates.
+const DAMPENER_L1_THRESHOLD: f32 = 0.2;
+
+/// Multiplicative dampener factor applied to low-confidence L3 signals.
+const DAMPENER_FACTOR: f32 = 0.4;
+
+impl VerdictCombiner for DefaultVerdictCombiner {
+    fn combine(&self, signals: &[Signal]) -> Verdict {
+        // Step 1: Atomic fast-path
+        for s in signals {
+            if s.kind == SignalKind::AtomicBlock {
+                return Verdict {
+                    action: VerdictAction::Block,
+                    composite_score: 1.0,
+                    contributing: vec![SignalContribution {
+                        layer: s.layer,
+                        category: s.category.clone(),
+                        raw_score: s.score,
+                        weighted_score: s.score,
+                    }],
+                };
+            }
+        }
+
+        // Collect only Evidence signals (AtomicBlock already handled).
+        let evidence: Vec<&Signal> = signals
+            .iter()
+            .filter(|s| s.kind == SignalKind::Evidence && s.score > 0.0)
+            .collect();
+
+        if evidence.is_empty() {
+            return Verdict {
+                action: VerdictAction::Allow,
+                composite_score: 0.0,
+                contributing: vec![],
+            };
+        }
+
+        // Step 2: Dampener — compute L1 aggregate, then dampen eligible L3 signals.
+        let l1_max = evidence
+            .iter()
+            .filter(|s| s.layer == LayerId::L1)
+            .map(|s| s.score)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let l1_max = if l1_max == f32::NEG_INFINITY { 0.5 } else { l1_max };
+
+        let dampen_l3 = l1_max < DAMPENER_L1_THRESHOLD;
+
+        // Build contributions with effective (post-dampener) scores.
+        let mut contributions: Vec<SignalContribution> = Vec::with_capacity(evidence.len());
+        let mut effective_scores: Vec<(LayerId, f32, f32)> = Vec::with_capacity(evidence.len());
+
+        for s in &evidence {
+            let weighted = if dampen_l3 && s.layer == LayerId::L3 && s.confidence < 1.0 {
+                s.score * DAMPENER_FACTOR
+            } else {
+                s.score
+            };
+            contributions.push(SignalContribution {
+                layer: s.layer,
+                category: s.category.clone(),
+                raw_score: s.score,
+                weighted_score: weighted,
+            });
+            effective_scores.push((s.layer, weighted, s.confidence));
+        }
+
+        // Step 3: Baseline = max effective score.
+        let baseline = effective_scores
+            .iter()
+            .map(|(_, score, _)| *score)
+            .fold(0.0_f32, f32::max);
+
+        // Step 4: Cross-layer boost.
+        // Collect unique layers with effective_score >= AGREEMENT_THRESHOLD.
+        let agreeing_layers: HashSet<LayerId> = effective_scores
+            .iter()
+            .filter(|(_, score, _)| *score >= AGREEMENT_THRESHOLD)
+            .map(|(layer, _, _)| *layer)
+            .collect();
+
+        let boost = if agreeing_layers.len() >= 2 {
+            // min confidence among all agreeing signals
+            let min_conf = effective_scores
+                .iter()
+                .filter(|(layer, score, _)| {
+                    agreeing_layers.contains(layer) && *score >= AGREEMENT_THRESHOLD
+                })
+                .map(|(_, _, conf)| *conf)
+                .fold(f32::INFINITY, f32::min);
+            let min_conf = if min_conf == f32::INFINITY { 0.0 } else { min_conf };
+            BOOST_FACTOR * min_conf
+        } else {
+            0.0
+        };
+
+        // Step 5: Composite + action.
+        let composite = (baseline + boost).clamp(0.0, 1.0);
+        let action = if composite >= BLOCK_THRESHOLD {
+            VerdictAction::Block
+        } else {
+            VerdictAction::Allow
+        };
+
+        Verdict {
+            action,
+            composite_score: composite,
+            contributing: contributions,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn evidence(layer: LayerId, score: f32, confidence: f32) -> Signal {
+        Signal::new(layer, SignalKind::Evidence, None, score, confidence)
+    }
+
+    fn evidence_cat(
+        layer: LayerId,
+        score: f32,
+        confidence: f32,
+        category: &str,
+    ) -> Signal {
+        Signal::new(
+            layer,
+            SignalKind::Evidence,
+            Some(category.to_string()),
+            score,
+            confidence,
+        )
+    }
+
+    fn atomic(layer: LayerId) -> Signal {
+        Signal::new(layer, SignalKind::AtomicBlock, None, 1.0, 1.0)
+    }
+
+    #[test]
+    fn atomic_fast_path_returns_block() {
+        let combiner = DefaultVerdictCombiner::new();
+        let verdict = combiner.combine(&[atomic(LayerId::L3)]);
+        assert_eq!(verdict.action, VerdictAction::Block);
+        assert!((verdict.composite_score - 1.0).abs() < f32::EPSILON);
+        assert_eq!(verdict.contributing.len(), 1);
+    }
+
+    #[test]
+    fn single_evidence_baseline_only() {
+        let combiner = DefaultVerdictCombiner::new();
+        let verdict = combiner.combine(&[evidence(LayerId::L3, 0.5, 1.0)]);
+        // No L1 signals → l1_max = 0.5, no dampening. Single layer → no boost.
+        assert!((verdict.composite_score - 0.5).abs() < f32::EPSILON);
+        assert_eq!(verdict.action, VerdictAction::Block); // 0.5 >= threshold
+    }
+
+    #[test]
+    fn below_threshold_allows() {
+        let combiner = DefaultVerdictCombiner::new();
+        let verdict = combiner.combine(&[evidence(LayerId::L3, 0.3, 1.0)]);
+        assert_eq!(verdict.action, VerdictAction::Allow);
+        assert!((verdict.composite_score - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cross_layer_boost_applied() {
+        let combiner = DefaultVerdictCombiner::new();
+        let signals = vec![
+            evidence(LayerId::L1, 0.6, 1.0),
+            evidence(LayerId::L3, 0.4, 1.0),
+        ];
+        let verdict = combiner.combine(&signals);
+        // baseline = max(0.6, 0.4) = 0.6
+        // Both >= 0.3, different layers → boost = 0.2 * min(1.0, 1.0) = 0.2
+        // composite = 0.6 + 0.2 = 0.8
+        assert!((verdict.composite_score - 0.8).abs() < f32::EPSILON);
+        assert_eq!(verdict.action, VerdictAction::Block);
+    }
+
+    #[test]
+    fn no_self_boost_same_layer() {
+        let combiner = DefaultVerdictCombiner::new();
+        let signals = vec![
+            evidence_cat(LayerId::L3, 0.5, 1.0, "cat_a"),
+            evidence_cat(LayerId::L3, 0.4, 1.0, "cat_b"),
+        ];
+        let verdict = combiner.combine(&signals);
+        // Both L3 → only 1 unique layer → no boost
+        // baseline = max(0.5, 0.4) = 0.5
+        assert!((verdict.composite_score - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn dampener_targets_low_confidence_l3_only() {
+        let combiner = DefaultVerdictCombiner::new();
+        let signals = vec![
+            evidence(LayerId::L1, 0.1, 1.0),          // L1 < 0.2 → dampener active
+            evidence(LayerId::L3, 0.8, 1.0),           // block-action (confidence 1.0) → NOT dampened
+            evidence(LayerId::L3, 0.8, 0.6),           // evidence-action (confidence 0.6) → dampened
+        ];
+        let verdict = combiner.combine(&signals);
+        // L3 block-action: effective = 0.8 (undampened)
+        // L3 evidence-action: effective = 0.8 * 0.4 = 0.32
+        // baseline = max(0.1, 0.8, 0.32) = 0.8
+        // L1 effective 0.1 < 0.3 → doesn't count for agreement
+        // L3 effective 0.8 >= 0.3 → counts, but only one unique layer (L3) → no boost
+        // composite = 0.8
+        assert!((verdict.composite_score - 0.8).abs() < f32::EPSILON);
+
+        // Verify contributions reflect dampening
+        let l3_evidence = verdict
+            .contributing
+            .iter()
+            .find(|c| c.layer == LayerId::L3 && (c.weighted_score - 0.32).abs() < f32::EPSILON);
+        assert!(l3_evidence.is_some(), "dampened L3 evidence signal should have weighted_score 0.32");
+    }
+
+    #[test]
+    fn no_dampener_when_l1_absent() {
+        let combiner = DefaultVerdictCombiner::new();
+        let signals = vec![evidence(LayerId::L3, 0.8, 0.6)];
+        let verdict = combiner.combine(&signals);
+        // No L1 → l1_max = 0.5, no dampening
+        // effective = 0.8 (undampened)
+        assert!((verdict.composite_score - 0.8).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn high_composite_recommends_block() {
+        let combiner = DefaultVerdictCombiner::new();
+        let signals = vec![evidence(LayerId::L1, 0.9, 1.0)];
+        let verdict = combiner.combine(&signals);
+        assert_eq!(verdict.action, VerdictAction::Block);
+    }
+
+    #[test]
+    fn low_composite_recommends_allow() {
+        let combiner = DefaultVerdictCombiner::new();
+        let signals = vec![evidence(LayerId::L1, 0.2, 1.0)];
+        let verdict = combiner.combine(&signals);
+        assert_eq!(verdict.action, VerdictAction::Allow);
+    }
+
+    #[test]
+    fn empty_signals_returns_allow() {
+        let combiner = DefaultVerdictCombiner::new();
+        let verdict = combiner.combine(&[]);
+        assert_eq!(verdict.action, VerdictAction::Allow);
+        assert_eq!(verdict.composite_score, 0.0);
+    }
+}

--- a/parapet/src/signal/extractor.rs
+++ b/parapet/src/signal/extractor.rs
@@ -1,0 +1,287 @@
+// Copyright 2026 The Parapet Project
+// SPDX-License-Identifier: Apache-2.0
+
+// Signal extraction — converts layer results into unified Signal types.
+
+use crate::config::{Config, PatternAction};
+use crate::layers::l1::L1Result;
+use crate::layers::l3_inbound::InboundResult;
+use crate::layers::l4::L4Result;
+
+use super::{LayerId, Signal, SignalKind};
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// Converts layer results into signals for the verdict processor.
+pub trait SignalExtractor: Send + Sync {
+    fn extract_l1(&self, result: &L1Result) -> Vec<Signal>;
+    fn extract_l3(&self, result: &InboundResult, config: &Config) -> Vec<Signal>;
+    fn extract_l4(&self, result: &L4Result) -> Vec<Signal>;
+}
+
+// ---------------------------------------------------------------------------
+// Default implementation
+// ---------------------------------------------------------------------------
+
+pub struct DefaultSignalExtractor;
+
+impl DefaultSignalExtractor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SignalExtractor for DefaultSignalExtractor {
+    fn extract_l1(&self, result: &L1Result) -> Vec<Signal> {
+        result
+            .per_message_scores
+            .iter()
+            .filter(|m| m.calibrated > 0.0)
+            .map(|m| {
+                Signal::new(
+                    LayerId::L1,
+                    SignalKind::Evidence,
+                    None,
+                    m.calibrated,
+                    1.0, // L1 is calibrated; fixed constant
+                )
+            })
+            .collect()
+    }
+
+    fn extract_l3(&self, result: &InboundResult, config: &Config) -> Vec<Signal> {
+        result
+            .matched_patterns
+            .iter()
+            .filter_map(|m| {
+                let pattern = config.policy.block_patterns.get(m.pattern_index)?;
+                let kind = if pattern.atomic {
+                    SignalKind::AtomicBlock
+                } else {
+                    SignalKind::Evidence
+                };
+                let confidence = if pattern.action == PatternAction::Block {
+                    1.0
+                } else {
+                    0.6
+                };
+                Some(Signal::new(
+                    LayerId::L3,
+                    kind,
+                    pattern.category.clone(),
+                    pattern.weight as f32, // clamped by Signal::new
+                    confidence,
+                ))
+            })
+            .collect()
+    }
+
+    fn extract_l4(&self, result: &L4Result) -> Vec<Signal> {
+        let mut signals = Vec::new();
+
+        // Aggregate risk score
+        if result.risk_score > 0.0 {
+            signals.push(Signal::new(
+                LayerId::L4,
+                SignalKind::Evidence,
+                None,
+                result.risk_score as f32,
+                1.0,
+            ));
+        }
+
+        // Per-category signals
+        for cat in &result.matched_categories {
+            if cat.weight > 0.0 {
+                signals.push(Signal::new(
+                    LayerId::L4,
+                    SignalKind::Evidence,
+                    Some(cat.category.clone()),
+                    cat.weight as f32, // clamped by Signal::new
+                    0.8,               // L4 categories are heuristic
+                ));
+            }
+        }
+
+        signals
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CompiledPattern, PatternAction};
+    use crate::layers::l1::{L1MessageScore, L1Result, L1Verdict};
+    use crate::layers::l3_inbound::{InboundResult, InboundVerdict, MatchSource, PatternMatch};
+    use crate::layers::l4::{L4CategoryMatch, L4Result, L4Verdict};
+    use crate::message::Role;
+
+    fn make_config_with_patterns(patterns: Vec<CompiledPattern>) -> Config {
+        use crate::config::*;
+        use std::collections::HashMap;
+        Config {
+            policy: PolicyConfig {
+                version: "v1".to_string(),
+                tools: HashMap::new(),
+                block_patterns: patterns,
+                canary_tokens: vec![],
+                sensitive_patterns: vec![],
+                untrusted_content_policy: ContentPolicy::default(),
+                trust: TrustConfig::default(),
+                layers: LayerConfigs::default(),
+            },
+            runtime: RuntimeConfig {
+                engine: EngineConfig::default(),
+                environment: "test".to_string(),
+            },
+            contract_hash: "sha256:test".to_string(),
+        }
+    }
+
+    #[test]
+    fn l1_extraction_skips_zero_scores() {
+        let extractor = DefaultSignalExtractor::new();
+        let result = L1Result {
+            verdict: L1Verdict::Allow,
+            per_message_scores: vec![
+                L1MessageScore { message_index: 0, role: Role::User, score: -1.0, calibrated: 0.0 },
+                L1MessageScore { message_index: 1, role: Role::User, score: 0.5, calibrated: 0.4 },
+                L1MessageScore { message_index: 2, role: Role::User, score: 2.0, calibrated: 0.8 },
+            ],
+        };
+        let signals = extractor.extract_l1(&result);
+        assert_eq!(signals.len(), 2);
+        assert!((signals[0].score - 0.4).abs() < f32::EPSILON);
+        assert!((signals[1].score - 0.8).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn l3_extraction_atomic_pattern() {
+        let extractor = DefaultSignalExtractor::new();
+        let pattern = CompiledPattern::compile_full(
+            "exploit",
+            PatternAction::Block,
+            None,
+            Some("template_abuse".to_string()),
+            1.0,
+            true, // atomic
+        )
+        .unwrap();
+        let config = make_config_with_patterns(vec![pattern]);
+
+        let result = InboundResult {
+            verdict: InboundVerdict::Allow,
+            matched_patterns: vec![PatternMatch {
+                pattern_index: 0,
+                message_index: 0,
+                role: Role::User,
+                source: MatchSource::Content,
+                action: PatternAction::Block,
+            }],
+        };
+        let signals = extractor.extract_l3(&result, &config);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].kind, SignalKind::AtomicBlock);
+        assert_eq!(signals[0].category.as_deref(), Some("template_abuse"));
+    }
+
+    #[test]
+    fn l3_extraction_evidence_pattern() {
+        let extractor = DefaultSignalExtractor::new();
+        let pattern = CompiledPattern::compile_full(
+            "suspicious",
+            PatternAction::Evidence,
+            None,
+            Some("roleplay".to_string()),
+            0.7,
+            false,
+        )
+        .unwrap();
+        let config = make_config_with_patterns(vec![pattern]);
+
+        let result = InboundResult {
+            verdict: InboundVerdict::Allow,
+            matched_patterns: vec![PatternMatch {
+                pattern_index: 0,
+                message_index: 0,
+                role: Role::User,
+                source: MatchSource::Content,
+                action: PatternAction::Evidence,
+            }],
+        };
+        let signals = extractor.extract_l3(&result, &config);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].kind, SignalKind::Evidence);
+        assert!((signals[0].score - 0.7).abs() < f32::EPSILON);
+        assert!((signals[0].confidence - 0.6).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn l3_extraction_resolves_metadata_from_config() {
+        let extractor = DefaultSignalExtractor::new();
+        let pattern = CompiledPattern::compile_full(
+            "test",
+            PatternAction::Block,
+            None,
+            Some("injection".to_string()),
+            0.9,
+            false,
+        )
+        .unwrap();
+        let config = make_config_with_patterns(vec![pattern]);
+
+        let result = InboundResult {
+            verdict: InboundVerdict::Allow,
+            matched_patterns: vec![PatternMatch {
+                pattern_index: 0,
+                message_index: 0,
+                role: Role::User,
+                source: MatchSource::Content,
+                action: PatternAction::Block,
+            }],
+        };
+        let signals = extractor.extract_l3(&result, &config);
+        assert_eq!(signals[0].category.as_deref(), Some("injection"));
+        assert!((signals[0].score - 0.9).abs() < f32::EPSILON);
+        assert!((signals[0].confidence - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn l4_extraction_aggregate_and_categories() {
+        let extractor = DefaultSignalExtractor::new();
+        let result = L4Result {
+            verdict: L4Verdict::Allow,
+            risk_score: 0.6,
+            matched_categories: vec![
+                L4CategoryMatch {
+                    category: "instruction_seeding".to_string(),
+                    weight: 0.4,
+                    turn_indices: vec![0, 2],
+                },
+                L4CategoryMatch {
+                    category: "role_confusion".to_string(),
+                    weight: 0.3,
+                    turn_indices: vec![1],
+                },
+            ],
+            flagged_turns: vec![0, 1, 2],
+        };
+        let signals = extractor.extract_l4(&result);
+        assert_eq!(signals.len(), 3); // 1 aggregate + 2 categories
+        // Aggregate
+        assert_eq!(signals[0].layer, LayerId::L4);
+        assert!(signals[0].category.is_none());
+        assert!((signals[0].score - 0.6).abs() < f32::EPSILON);
+        assert!((signals[0].confidence - 1.0).abs() < f32::EPSILON);
+        // Categories
+        assert_eq!(signals[1].category.as_deref(), Some("instruction_seeding"));
+        assert!((signals[1].confidence - 0.8).abs() < f32::EPSILON);
+        assert_eq!(signals[2].category.as_deref(), Some("role_confusion"));
+    }
+}

--- a/parapet/src/signal/mod.rs
+++ b/parapet/src/signal/mod.rs
@@ -1,0 +1,163 @@
+// Copyright 2026 The Parapet Project
+// SPDX-License-Identifier: Apache-2.0
+
+// Signal types for the verdict processor.
+//
+// Layers emit Signals (normalized observations). The VerdictCombiner combines
+// them into a composite Verdict. In shadow mode the engine logs the verdict
+// but does not enforce it.
+
+pub mod combiner;
+pub mod extractor;
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+/// Identifies which layer produced a signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LayerId {
+    L1,
+    L3,
+    L4,
+}
+
+impl std::fmt::Display for LayerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LayerId::L1 => write!(f, "L1"),
+            LayerId::L3 => write!(f, "L3"),
+            LayerId::L4 => write!(f, "L4"),
+        }
+    }
+}
+
+/// Whether a signal is an atomic (hard) block or soft evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalKind {
+    /// Non-negotiable: match = block. Bypasses the combiner.
+    AtomicBlock,
+    /// Contributes to composite score.
+    Evidence,
+}
+
+/// A normalized observation emitted by a layer.
+#[derive(Debug, Clone)]
+pub struct Signal {
+    pub layer: LayerId,
+    pub kind: SignalKind,
+    pub category: Option<String>,
+    /// Strength of the observation, clamped to [0.0, 1.0].
+    pub score: f32,
+    /// Reliability of the sensor for this observation, clamped to [0.0, 1.0].
+    pub confidence: f32,
+}
+
+impl Signal {
+    /// Construct a signal with clamped score and confidence.
+    ///
+    /// NaN and -INFINITY clamp to 0.0; INFINITY clamps to 1.0.
+    pub fn new(
+        layer: LayerId,
+        kind: SignalKind,
+        category: Option<String>,
+        score: f32,
+        confidence: f32,
+    ) -> Self {
+        Self {
+            layer,
+            kind,
+            category,
+            score: clamp_f32(score),
+            confidence: clamp_f32(confidence),
+        }
+    }
+}
+
+/// Clamp a f32 to [0.0, 1.0], handling NaN and infinities.
+fn clamp_f32(v: f32) -> f32 {
+    if v.is_nan() || v == f32::NEG_INFINITY {
+        0.0
+    } else if v == f32::INFINITY {
+        1.0
+    } else {
+        v.clamp(0.0, 1.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Verdict types
+// ---------------------------------------------------------------------------
+
+/// The combiner's recommended action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerdictAction {
+    Allow,
+    Block,
+}
+
+/// Composite verdict produced by the combiner.
+#[derive(Debug, Clone)]
+pub struct Verdict {
+    pub action: VerdictAction,
+    pub composite_score: f32,
+    pub contributing: Vec<SignalContribution>,
+}
+
+/// What a single signal contributed to the verdict.
+#[derive(Debug, Clone)]
+pub struct SignalContribution {
+    pub layer: LayerId,
+    pub category: Option<String>,
+    /// Score before dampening.
+    pub raw_score: f32,
+    /// Post-dampener score. Equal to `raw_score` unless the dampener fired.
+    pub weighted_score: f32,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signal_new_clamps_nan_to_zero() {
+        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, f32::NAN, f32::NAN);
+        assert_eq!(s.score, 0.0);
+        assert_eq!(s.confidence, 0.0);
+    }
+
+    #[test]
+    fn signal_new_clamps_neg_infinity_to_zero() {
+        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, f32::NEG_INFINITY, 0.5);
+        assert_eq!(s.score, 0.0);
+    }
+
+    #[test]
+    fn signal_new_clamps_infinity_to_one() {
+        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, f32::INFINITY, 0.5);
+        assert_eq!(s.score, 1.0);
+    }
+
+    #[test]
+    fn signal_new_clamps_negative_to_zero() {
+        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, -0.5, 0.5);
+        assert_eq!(s.score, 0.0);
+    }
+
+    #[test]
+    fn signal_new_clamps_above_one() {
+        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, 1.5, 0.5);
+        assert_eq!(s.score, 1.0);
+    }
+
+    #[test]
+    fn signal_new_preserves_valid_values() {
+        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, 0.7, 0.9);
+        assert!((s.score - 0.7).abs() < f32::EPSILON);
+        assert!((s.confidence - 0.9).abs() < f32::EPSILON);
+    }
+}

--- a/parapet/tests/integration.rs
+++ b/parapet/tests/integration.rs
@@ -19,6 +19,8 @@ use parapet::layers::l3_inbound::DefaultInboundScanner;
 use parapet::layers::l5a::L5aScanner;
 use parapet::normalize::L0Normalizer;
 use parapet::proxy::{self, Provider};
+use parapet::signal::combiner::DefaultVerdictCombiner;
+use parapet::signal::extractor::DefaultSignalExtractor;
 use parapet::trust::RoleTrustAssigner;
 use std::sync::Arc;
 use tower::ServiceExt;
@@ -102,6 +104,8 @@ fn build_test_engine(yaml: &str, mock_url: &str) -> EngineUpstreamClient {
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        signal_extractor: Arc::new(DefaultSignalExtractor),
+        verdict_combiner: Arc::new(DefaultVerdictCombiner),
     };
 
     EngineUpstreamClient::new_with(deps)


### PR DESCRIPTION
## Summary

- Add unified `Signal`, `LayerId`, `SignalKind` types with NaN/infinity clamping
- `SignalExtractor` trait + `DefaultSignalExtractor` for L1, L3 (config-aware), L4
- `VerdictCombiner` trait + `DefaultVerdictCombiner`: atomic fast-path, multiplicative dampener, max baseline, cross-layer boost
- Engine wiring in shadow mode — logs recommended verdict but does not enforce (zero behavioral delta)
- DI via traits injected into `EngineDeps`

## Test plan

- [ ] 500 tests pass (490 unit + 10 integration)
- [ ] Eval baseline identical to v4/v5 (L1: 3100/57/34/22323, L3: 646/1694/7666/7395, L4: 96/35/988/10031)
- [ ] Shadow mode confirmed: no headers or status codes change

🤖 Generated with [Claude Code](https://claude.com/claude-code)