### PR TITLE
Rename signal layer identifiers

### DIFF
--- a/parapet/src/engine/tests.rs
+++ b/parapet/src/engine/tests.rs
@@ -2086,7 +2086,7 @@ fn l2a_test_config() -> L2aConfig {
 
 fn l2a_signal(score: f32, category: &str) -> Signal {
     Signal {
-        layer: LayerId::L2a,
+        layer: LayerId::PayloadScan,
         kind: SignalKind::Evidence,
         score,
         confidence: 0.9,

--- a/parapet/src/layers/l2a.rs
+++ b/parapet/src/layers/l2a.rs
@@ -518,7 +518,7 @@ impl L2aScanner for DefaultL2aScanner {
                 // Defensive: score > 0 but no categories (shouldn't happen
                 // given fusion logic). Emit one signal with category: None.
                 let mut signal = Signal::new(
-                    LayerId::L2a,
+                    LayerId::PayloadScan,
                     SignalKind::Evidence,
                     None,
                     score,
@@ -532,7 +532,7 @@ impl L2aScanner for DefaultL2aScanner {
                 // One signal per category.
                 for cat in categories {
                     let mut signal = Signal::new(
-                        LayerId::L2a,
+                        LayerId::PayloadScan,
                         SignalKind::Evidence,
                         Some(cat),
                         score,
@@ -1350,7 +1350,7 @@ mod tests {
 
         // All signals are L2a Evidence
         for sig in &signals {
-            assert_eq!(sig.layer, LayerId::L2a);
+            assert_eq!(sig.layer, LayerId::PayloadScan);
             assert_eq!(sig.kind, SignalKind::Evidence);
             assert_eq!(sig.message_index, Some(0));
             assert!(sig.segment_id.is_some());

--- a/parapet/src/signal/combiner.rs
+++ b/parapet/src/signal/combiner.rs
@@ -41,10 +41,10 @@ const BOOST_FACTOR: f32 = 0.2;
 /// Minimum signal score to count as "agreeing" for cross-layer boost.
 const AGREEMENT_THRESHOLD: f32 = 0.3;
 
-/// L1 score below which the dampener activates.
-const DAMPENER_L1_THRESHOLD: f32 = 0.2;
+/// Lexical-classifier score below which the dampener activates.
+const DAMPENER_LEXICAL_THRESHOLD: f32 = 0.2;
 
-/// Multiplicative dampener factor applied to low-confidence L3 signals.
+/// Multiplicative dampener factor applied to low-confidence pattern-gate signals.
 const DAMPENER_FACTOR: f32 = 0.4;
 
 impl VerdictCombiner for DefaultVerdictCombiner {
@@ -79,22 +79,22 @@ impl VerdictCombiner for DefaultVerdictCombiner {
             };
         }
 
-        // Step 2: Dampener — compute L1 aggregate, then dampen eligible L3 signals.
-        let l1_max = evidence
+        // Step 2: Dampener — compute lexical aggregate, then dampen eligible pattern signals.
+        let lexical_max = evidence
             .iter()
-            .filter(|s| s.layer == LayerId::L1)
+            .filter(|s| s.layer == LayerId::LexicalClassifier)
             .map(|s| s.score)
             .fold(f32::NEG_INFINITY, f32::max);
-        let l1_max = if l1_max == f32::NEG_INFINITY { 0.5 } else { l1_max };
+        let lexical_max = if lexical_max == f32::NEG_INFINITY { 0.5 } else { lexical_max };
 
-        let dampen_l3 = l1_max < DAMPENER_L1_THRESHOLD;
+        let dampen_pattern_gate = lexical_max < DAMPENER_LEXICAL_THRESHOLD;
 
         // Build contributions with effective (post-dampener) scores.
         let mut contributions: Vec<SignalContribution> = Vec::with_capacity(evidence.len());
         let mut effective_scores: Vec<(LayerId, f32, f32)> = Vec::with_capacity(evidence.len());
 
         for s in &evidence {
-            let weighted = if dampen_l3 && s.layer == LayerId::L3 && s.confidence < 1.0 {
+            let weighted = if dampen_pattern_gate && s.layer == LayerId::PatternGate && s.confidence < 1.0 {
                 s.score * DAMPENER_FACTOR
             } else {
                 s.score
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn atomic_fast_path_returns_block() {
         let combiner = DefaultVerdictCombiner::new();
-        let verdict = combiner.combine(&[atomic(LayerId::L3)]);
+        let verdict = combiner.combine(&[atomic(LayerId::PatternGate)]);
         assert_eq!(verdict.action, VerdictAction::Block);
         assert!((verdict.composite_score - 1.0).abs() < f32::EPSILON);
         assert_eq!(verdict.contributing.len(), 1);
@@ -196,8 +196,8 @@ mod tests {
     #[test]
     fn single_evidence_baseline_only() {
         let combiner = DefaultVerdictCombiner::new();
-        let verdict = combiner.combine(&[evidence(LayerId::L3, 0.5, 1.0)]);
-        // No L1 signals → l1_max = 0.5, no dampening. Single layer → no boost.
+        let verdict = combiner.combine(&[evidence(LayerId::PatternGate, 0.5, 1.0)]);
+        // No lexical signals → lexical_max = 0.5, no dampening. Single layer → no boost.
         assert!((verdict.composite_score - 0.5).abs() < f32::EPSILON);
         assert_eq!(verdict.action, VerdictAction::Block); // 0.5 >= threshold
     }
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn below_threshold_allows() {
         let combiner = DefaultVerdictCombiner::new();
-        let verdict = combiner.combine(&[evidence(LayerId::L3, 0.3, 1.0)]);
+        let verdict = combiner.combine(&[evidence(LayerId::PatternGate, 0.3, 1.0)]);
         assert_eq!(verdict.action, VerdictAction::Allow);
         assert!((verdict.composite_score - 0.3).abs() < f32::EPSILON);
     }
@@ -214,8 +214,8 @@ mod tests {
     fn cross_layer_boost_applied() {
         let combiner = DefaultVerdictCombiner::new();
         let signals = vec![
-            evidence(LayerId::L1, 0.6, 1.0),
-            evidence(LayerId::L3, 0.4, 1.0),
+            evidence(LayerId::LexicalClassifier, 0.6, 1.0),
+            evidence(LayerId::PatternGate, 0.4, 1.0),
         ];
         let verdict = combiner.combine(&signals);
         // baseline = max(0.6, 0.4) = 0.6
@@ -229,46 +229,46 @@ mod tests {
     fn no_self_boost_same_layer() {
         let combiner = DefaultVerdictCombiner::new();
         let signals = vec![
-            evidence_cat(LayerId::L3, 0.5, 1.0, "cat_a"),
-            evidence_cat(LayerId::L3, 0.4, 1.0, "cat_b"),
+            evidence_cat(LayerId::PatternGate, 0.5, 1.0, "cat_a"),
+            evidence_cat(LayerId::PatternGate, 0.4, 1.0, "cat_b"),
         ];
         let verdict = combiner.combine(&signals);
-        // Both L3 → only 1 unique layer → no boost
+        // Both pattern-gate signals → only 1 unique layer → no boost
         // baseline = max(0.5, 0.4) = 0.5
         assert!((verdict.composite_score - 0.5).abs() < f32::EPSILON);
     }
 
     #[test]
-    fn dampener_targets_low_confidence_l3_only() {
+    fn dampener_targets_low_confidence_pattern_gate_only() {
         let combiner = DefaultVerdictCombiner::new();
         let signals = vec![
-            evidence(LayerId::L1, 0.1, 1.0),          // L1 < 0.2 → dampener active
-            evidence(LayerId::L3, 0.8, 1.0),           // block-action (confidence 1.0) → NOT dampened
-            evidence(LayerId::L3, 0.8, 0.6),           // evidence-action (confidence 0.6) → dampened
+            evidence(LayerId::LexicalClassifier, 0.1, 1.0), // lexical < 0.2 → dampener active
+            evidence(LayerId::PatternGate, 0.8, 1.0),       // block-action (confidence 1.0) → NOT dampened
+            evidence(LayerId::PatternGate, 0.8, 0.6),       // evidence-action (confidence 0.6) → dampened
         ];
         let verdict = combiner.combine(&signals);
-        // L3 block-action: effective = 0.8 (undampened)
-        // L3 evidence-action: effective = 0.8 * 0.4 = 0.32
+        // Pattern block-action: effective = 0.8 (undampened)
+        // Pattern evidence-action: effective = 0.8 * 0.4 = 0.32
         // baseline = max(0.1, 0.8, 0.32) = 0.8
-        // L1 effective 0.1 < 0.3 → doesn't count for agreement
-        // L3 effective 0.8 >= 0.3 → counts, but only one unique layer (L3) → no boost
+        // Lexical effective 0.1 < 0.3 → doesn't count for agreement
+        // Pattern effective 0.8 >= 0.3 → counts, but only one unique layer → no boost
         // composite = 0.8
         assert!((verdict.composite_score - 0.8).abs() < f32::EPSILON);
 
         // Verify contributions reflect dampening
-        let l3_evidence = verdict
+        let pattern_evidence = verdict
             .contributing
             .iter()
-            .find(|c| c.layer == LayerId::L3 && (c.weighted_score - 0.32).abs() < f32::EPSILON);
-        assert!(l3_evidence.is_some(), "dampened L3 evidence signal should have weighted_score 0.32");
+            .find(|c| c.layer == LayerId::PatternGate && (c.weighted_score - 0.32).abs() < f32::EPSILON);
+        assert!(pattern_evidence.is_some(), "dampened pattern-gate evidence signal should have weighted_score 0.32");
     }
 
     #[test]
     fn no_dampener_when_l1_absent() {
         let combiner = DefaultVerdictCombiner::new();
-        let signals = vec![evidence(LayerId::L3, 0.8, 0.6)];
+        let signals = vec![evidence(LayerId::PatternGate, 0.8, 0.6)];
         let verdict = combiner.combine(&signals);
-        // No L1 → l1_max = 0.5, no dampening
+        // No lexical signal → lexical_max = 0.5, no dampening
         // effective = 0.8 (undampened)
         assert!((verdict.composite_score - 0.8).abs() < f32::EPSILON);
     }
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn high_composite_recommends_block() {
         let combiner = DefaultVerdictCombiner::new();
-        let signals = vec![evidence(LayerId::L1, 0.9, 1.0)];
+        let signals = vec![evidence(LayerId::LexicalClassifier, 0.9, 1.0)];
         let verdict = combiner.combine(&signals);
         assert_eq!(verdict.action, VerdictAction::Block);
     }
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn low_composite_recommends_allow() {
         let combiner = DefaultVerdictCombiner::new();
-        let signals = vec![evidence(LayerId::L1, 0.2, 1.0)];
+        let signals = vec![evidence(LayerId::LexicalClassifier, 0.2, 1.0)];
         let verdict = combiner.combine(&signals);
         assert_eq!(verdict.action, VerdictAction::Allow);
     }

--- a/parapet/src/signal/extractor.rs
+++ b/parapet/src/signal/extractor.rs
@@ -54,7 +54,7 @@ impl SignalExtractor for DefaultSignalExtractor {
             .filter(|m| m.calibrated > 0.0)
             .map(|m| {
                 Signal::new(
-                    LayerId::L1,
+                    LayerId::LexicalClassifier,
                     SignalKind::Evidence,
                     m.specialist_name.clone(),
                     m.calibrated,
@@ -83,7 +83,7 @@ impl SignalExtractor for DefaultSignalExtractor {
             };
 
             let mut primary = Signal::new(
-                LayerId::L1,
+                LayerId::LexicalClassifier,
                 SignalKind::Evidence,
                 category,
                 primary_score,
@@ -97,7 +97,7 @@ impl SignalExtractor for DefaultSignalExtractor {
             // Compared against original score, not dampened score.
             if s.squash_score > s.score + OBFUSCATION_SCORE_GAP {
                 let mut obfusc = Signal::new(
-                    LayerId::L1,
+                    LayerId::LexicalClassifier,
                     SignalKind::Evidence,
                     Some("obfuscation".to_string()),
                     s.squash_score,
@@ -128,7 +128,7 @@ impl SignalExtractor for DefaultSignalExtractor {
                     0.6
                 };
                 Some(Signal::new(
-                    LayerId::L3,
+                    LayerId::PatternGate,
                     kind,
                     pattern.category.clone(),
                     pattern.weight as f32, // clamped by Signal::new
@@ -144,7 +144,7 @@ impl SignalExtractor for DefaultSignalExtractor {
         // Aggregate risk score
         if result.risk_score > 0.0 {
             signals.push(Signal::new(
-                LayerId::L4,
+                LayerId::MultiTurnRisk,
                 SignalKind::Evidence,
                 None,
                 result.risk_score as f32,
@@ -156,7 +156,7 @@ impl SignalExtractor for DefaultSignalExtractor {
         for cat in &result.matched_categories {
             if cat.weight > 0.0 {
                 signals.push(Signal::new(
-                    LayerId::L4,
+                    LayerId::MultiTurnRisk,
                     SignalKind::Evidence,
                     Some(cat.category.clone()),
                     cat.weight as f32, // clamped by Signal::new
@@ -335,7 +335,7 @@ mod tests {
         let signals = extractor.extract_l4(&result);
         assert_eq!(signals.len(), 3); // 1 aggregate + 2 categories
         // Aggregate
-        assert_eq!(signals[0].layer, LayerId::L4);
+        assert_eq!(signals[0].layer, LayerId::MultiTurnRisk);
         assert!(signals[0].category.is_none());
         assert!((signals[0].score - 0.6).abs() < f32::EPSILON);
         assert!((signals[0].confidence - 1.0).abs() < f32::EPSILON);
@@ -401,7 +401,7 @@ mod tests {
         let extracted = extractor.extract_l1_signals(&signals);
         assert_eq!(extracted.len(), 1);
         assert_eq!(extracted[0].message_index, Some(7));
-        assert_eq!(extracted[0].layer, LayerId::L1);
+        assert_eq!(extracted[0].layer, LayerId::LexicalClassifier);
         assert_eq!(extracted[0].kind, SignalKind::Evidence);
     }
 

--- a/parapet/src/signal/mod.rs
+++ b/parapet/src/signal/mod.rs
@@ -15,21 +15,26 @@ pub mod extractor;
 // ---------------------------------------------------------------------------
 
 /// Identifies which layer produced a signal.
+///
+/// Variants use semantic layer names rather than legacy numeric names. Not all
+/// variants are live in every build or configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LayerId {
-    L1,
-    L2a,
-    L3,
-    L4,
+    PatternGate,
+    LexicalClassifier,
+    PayloadScan,
+    HeuristicSignal,
+    MultiTurnRisk,
 }
 
 impl std::fmt::Display for LayerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LayerId::L1 => write!(f, "L1"),
-            LayerId::L2a => write!(f, "L2a"),
-            LayerId::L3 => write!(f, "L3"),
-            LayerId::L4 => write!(f, "L4"),
+            LayerId::PatternGate => write!(f, "PatternGate"),
+            LayerId::LexicalClassifier => write!(f, "LexicalClassifier"),
+            LayerId::PayloadScan => write!(f, "PayloadScan"),
+            LayerId::HeuristicSignal => write!(f, "HeuristicSignal"),
+            LayerId::MultiTurnRisk => write!(f, "MultiTurnRisk"),
         }
     }
 }
@@ -152,38 +157,38 @@ mod tests {
 
     #[test]
     fn signal_new_clamps_nan_to_zero() {
-        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, f32::NAN, f32::NAN);
+        let s = Signal::new(LayerId::LexicalClassifier, SignalKind::Evidence, None, f32::NAN, f32::NAN);
         assert_eq!(s.score, 0.0);
         assert_eq!(s.confidence, 0.0);
     }
 
     #[test]
     fn signal_new_clamps_neg_infinity_to_zero() {
-        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, f32::NEG_INFINITY, 0.5);
+        let s = Signal::new(LayerId::LexicalClassifier, SignalKind::Evidence, None, f32::NEG_INFINITY, 0.5);
         assert_eq!(s.score, 0.0);
     }
 
     #[test]
     fn signal_new_clamps_infinity_to_one() {
-        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, f32::INFINITY, 0.5);
+        let s = Signal::new(LayerId::LexicalClassifier, SignalKind::Evidence, None, f32::INFINITY, 0.5);
         assert_eq!(s.score, 1.0);
     }
 
     #[test]
     fn signal_new_clamps_negative_to_zero() {
-        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, -0.5, 0.5);
+        let s = Signal::new(LayerId::LexicalClassifier, SignalKind::Evidence, None, -0.5, 0.5);
         assert_eq!(s.score, 0.0);
     }
 
     #[test]
     fn signal_new_clamps_above_one() {
-        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, 1.5, 0.5);
+        let s = Signal::new(LayerId::LexicalClassifier, SignalKind::Evidence, None, 1.5, 0.5);
         assert_eq!(s.score, 1.0);
     }
 
     #[test]
     fn signal_new_preserves_valid_values() {
-        let s = Signal::new(LayerId::L1, SignalKind::Evidence, None, 0.7, 0.9);
+        let s = Signal::new(LayerId::LexicalClassifier, SignalKind::Evidence, None, 0.7, 0.9);
         assert!((s.score - 0.7).abs() < f32::EPSILON);
         assert!((s.confidence - 0.9).abs() < f32::EPSILON);
     }


### PR DESCRIPTION
 ## Summary

  - Rename `signal::LayerId` variants from legacy numeric names to semantic names:
    - `L1` -> `LexicalClassifier`
    - `L2a` -> `PayloadScan`
    - `L3` -> `PatternGate`
    - `L4` -> `MultiTurnRisk`
  - Add reserved `HeuristicSignal` variant for future deterministic routing
  signals.
  - Update direct signal extractor, combiner, L2a, and engine test call sites only.

  ## Validation

  - `cargo test signal` passed: 35 passed
  - `cargo test l2a` passed: 98 passed
  - `cargo test engine` passed: 99 passed
  - `git diff --check` passed
  - `python3 scripts/check_no_data_commit.py` passed
  - `rg "LayerId::L1|LayerId::L2a|LayerId::L3|LayerId::L4" parapet/src` returned
  zero matches

  ## Notes

  Mechanical rename only. No runtime behavior change, no new heuristic signal
  source, and no combiner enforcement change.

