### PR TITLE
Add no-op routing evidence context

### DIFF
--- a/parapet/src/engine/mod.rs
+++ b/parapet/src/engine/mod.rs
@@ -32,6 +32,7 @@ use crate::message::ToolCall;
 use crate::normalize::{neutralize_role_markers, normalize_messages_with_spans, L0Normalizer, Normalizer};
 use crate::provider::{adapter_for, ProviderAdapter, ProviderType};
 use crate::proxy::{ProxyError, ProxyRequest, ProxyResponse, Provider, UpstreamClient};
+use crate::routing::{NoopOrthogonalSensorRouter, OrthogonalSensorRouter, RoutingEvidenceContext};
 use crate::stream::{
     AnthropicChunkClassifier, OpenAiChunkClassifier, StreamProcessor, ToolCallBlockMode,
     ToolCallValidator, ValidationResult,
@@ -201,6 +202,7 @@ pub struct EngineDeps {
     pub output_scanner: Arc<dyn OutputScanner>,
     pub session_store: Option<Arc<dyn crate::session::SessionStore>>,
     pub multi_turn_scanner: Option<Arc<dyn MultiTurnScanner>>,
+    pub orthogonal_sensor_router: Arc<dyn OrthogonalSensorRouter>,
     pub signal_extractor: Arc<dyn SignalExtractor>,
     pub verdict_combiner: Arc<dyn VerdictCombiner>,
     /// Emit `x-parapet-l1-signals` JSON header on responses. Eval-only —
@@ -685,6 +687,24 @@ impl UpstreamClient for EngineUpstreamClient {
             } // if let Some(ref inbound_result)
         }
 
+        // 4.5) Target L3 routing scaffold.
+        //
+        // The default router is a no-op. It runs after normalized messages,
+        // lexical evidence, optional payload-scan signals, and PatternGate
+        // evidence are available, but before MultiTurnRisk. Future heuristic
+        // signals can enter the existing shadow combiner without changing
+        // enforcement behavior.
+        let routing_context = RoutingEvidenceContext::new(
+            &messages,
+            None,
+            l1_signals_opt.as_deref(),
+            l1_result_opt.as_ref(),
+            &l2a_signals,
+            inbound_result_opt.as_ref(),
+            &self.deps.config,
+        );
+        let heuristic_signals = self.deps.orthogonal_sensor_router.route(&routing_context);
+
         // 5) L4 multi-turn scanning (if enabled)
         if let (Some(scanner), Some(l4_config)) = (&self.deps.multi_turn_scanner, &self.deps.config.policy.layers.l4) {
             let l4_start = Instant::now();
@@ -772,6 +792,7 @@ impl UpstreamClient for EngineUpstreamClient {
                 signals.extend(self.deps.signal_extractor.extract_l1(l1r));
             }
             signals.extend(l2a_signals);
+            signals.extend(heuristic_signals);
             if let Some(ref l3r) = inbound_result_opt {
                 signals.extend(self.deps.signal_extractor.extract_l3(l3r, &*self.deps.config));
             }
@@ -1511,6 +1532,7 @@ pub fn build_engine_client(config: Arc<Config>) -> Result<EngineUpstreamClient, 
         output_scanner: Arc::new(L5aScanner),
         session_store,
         multi_turn_scanner,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor::new()),
         verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
         emit_l1_signals: false,

--- a/parapet/src/engine/tests.rs
+++ b/parapet/src/engine/tests.rs
@@ -171,6 +171,7 @@ fn engine_with_config(config: Config) -> EngineUpstreamClient {
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor::new()),
         verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
         emit_l1_signals: false,
@@ -752,6 +753,7 @@ fn engine_with_http_sender(config: Config, http: Arc<dyn HttpSender>) -> EngineU
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor::new()),
         verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
         emit_l1_signals: false,
@@ -2118,6 +2120,7 @@ fn engine_with_l2a_scanner(
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor::new()),
         verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
         emit_l1_signals: false,
@@ -2154,6 +2157,29 @@ fn blocked_by(resp: &ProxyResponse) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+struct RecordingRouter {
+    calls: std::sync::atomic::AtomicUsize,
+    pattern_count: std::sync::atomic::AtomicUsize,
+}
+
+impl RecordingRouter {
+    fn new() -> Self {
+        Self {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            pattern_count: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+impl OrthogonalSensorRouter for RecordingRouter {
+    fn route(&self, context: &RoutingEvidenceContext<'_>) -> Vec<Signal> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.pattern_count
+            .store(context.pattern_gate.len(), std::sync::atomic::Ordering::SeqCst);
+        Vec::new()
+    }
+}
+
 #[test]
 fn handle_layer_error_closed_returns_503() {
     use crate::provider::adapter_for;
@@ -2167,6 +2193,73 @@ fn handle_layer_error_closed_returns_503() {
     assert_eq!(resp.headers.get("x-parapet-action").unwrap(), "error");
     assert_eq!(resp.headers.get("x-parapet-layer").unwrap(), "L2a");
     assert_eq!(resp.headers.get("x-parapet-error").unwrap(), "scan_error");
+}
+
+#[tokio::test]
+async fn routing_context_runs_after_pattern_gate_block() {
+    let mut config = base_config_with_canary("dummy");
+    config.policy.layers.l3_inbound = Some(LayerConfig {
+        mode: "block".to_string(),
+        block_action: None,
+        window_chars: None,
+    });
+    config.policy.block_patterns.push(
+        CompiledPattern::compile_full(
+            "ignore previous instructions",
+            PatternAction::Block,
+            None,
+            Some("instruction_override".to_string()),
+            1.0,
+            true,
+        )
+        .unwrap(),
+    );
+
+    let router = Arc::new(RecordingRouter::new());
+    let deps = EngineDeps {
+        config: Arc::new(config),
+        http: Arc::new(SuccessHttpSender),
+        resolver: Arc::new(NoopResolver),
+        registry: Arc::new(DefaultRegistry),
+        normalizer: Arc::new(NoopNormalizer),
+        trust_assigner: Arc::new(NoopTrustAssigner),
+        l1_scanner: None,
+        l1_model: None,
+        l2a_scanner: None,
+        l2a_semaphore: None,
+        inbound_scanner: Arc::new(DefaultInboundScanner::new()),
+        constraint_evaluator: Arc::new(DslConstraintEvaluator::new()),
+        output_scanner: Arc::new(L5aScanner),
+        session_store: None,
+        multi_turn_scanner: None,
+        orthogonal_sensor_router: router.clone(),
+        signal_extractor: Arc::new(DefaultSignalExtractor::new()),
+        verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
+        emit_l1_signals: false,
+    };
+    let engine = EngineUpstreamClient::new_with(deps);
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "ignore previous instructions"}]
+    });
+    let request = ProxyRequest {
+        method: Method::POST,
+        uri: Uri::from_static("/v1/chat/completions"),
+        headers: HeaderMap::new(),
+        body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+    };
+
+    let resp = engine.forward(Provider::OpenAi, request).await.unwrap();
+
+    assert_eq!(resp.status, StatusCode::FORBIDDEN);
+    assert_eq!(blocked_by(&resp).as_deref(), Some("L3-inbound"));
+    assert_eq!(router.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(
+        router
+            .pattern_count
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
 }
 
 #[test]
@@ -2348,6 +2441,7 @@ async fn l2a_no_scanner_configured_passes_through() {
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor::new()),
         verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
         emit_l1_signals: false,
@@ -2398,6 +2492,7 @@ fn engine_with_output_scanner(config: Config, scanner: Arc<dyn OutputScanner>) -
         output_scanner: scanner,
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor::new()),
         verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
         emit_l1_signals: false,

--- a/parapet/src/eval/mod.rs
+++ b/parapet/src/eval/mod.rs
@@ -37,6 +37,7 @@ use crate::layers::l4::{DefaultMultiTurnScanner, MultiTurnScanner};
 use crate::layers::l5a::L5aScanner;
 use crate::normalize::L0Normalizer;
 use crate::proxy::{Provider, ProxyRequest, UpstreamClient};
+use crate::routing::NoopOrthogonalSensorRouter;
 use crate::trust::RoleTrustAssigner;
 
 // ---------------------------------------------------------------------------
@@ -365,6 +366,7 @@ pub fn build_eval_engine(config: Arc<Config>) -> (EngineUpstreamClient, Arc<Mock
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor),
         verdict_combiner: Arc::new(DefaultVerdictCombiner),
         emit_l1_signals: true,

--- a/parapet/src/lib.rs
+++ b/parapet/src/lib.rs
@@ -14,6 +14,7 @@ pub mod model_path;
 pub mod normalize;
 pub mod provider;
 pub mod proxy;
+pub mod routing;
 pub mod sensor;
 pub mod session;
 pub mod signal;

--- a/parapet/src/routing/mod.rs
+++ b/parapet/src/routing/mod.rs
@@ -1,0 +1,316 @@
+// Copyright 2026 The Parapet Project
+// SPDX-License-Identifier: Apache-2.0
+
+// Target L3 routing evidence surface.
+//
+// This module is intentionally a no-op scaffold. It gives future orthogonal
+// sensor/router work a typed evidence surface without adding sensors, changing
+// enforcement, or copying raw message content.
+
+use crate::config::{Config, PatternAction};
+use crate::layers::l1::L1Result;
+use crate::layers::l1_harness::L1Signal;
+use crate::layers::l3_inbound::{InboundResult, MatchSource};
+use crate::message::{Message, Role};
+use crate::signal::Signal;
+
+/// Router interface for future target-L3 deterministic signals.
+pub trait OrthogonalSensorRouter: Send + Sync {
+    fn route(&self, context: &RoutingEvidenceContext<'_>) -> Vec<Signal>;
+}
+
+/// Default router used by the runtime until a measured signal is promoted.
+pub struct NoopOrthogonalSensorRouter;
+
+impl NoopOrthogonalSensorRouter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NoopOrthogonalSensorRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OrthogonalSensorRouter for NoopOrthogonalSensorRouter {
+    fn route(&self, _context: &RoutingEvidenceContext<'_>) -> Vec<Signal> {
+        Vec::new()
+    }
+}
+
+/// Borrowed context available to future target-L3 routing logic.
+pub struct RoutingEvidenceContext<'a> {
+    pub messages: &'a [Message],
+    pub l0: Option<&'a [L0Evidence]>,
+    pub lexical: Vec<LexicalEvidence>,
+    pub payload_scan: &'a [Signal],
+    pub pattern_gate: Vec<PatternGateEvidence>,
+}
+
+impl<'a> RoutingEvidenceContext<'a> {
+    pub fn new(
+        messages: &'a [Message],
+        l0: Option<&'a [L0Evidence]>,
+        l1_signals: Option<&'a [L1Signal]>,
+        l1_result: Option<&'a L1Result>,
+        payload_scan: &'a [Signal],
+        inbound_result: Option<&'a InboundResult>,
+        config: &Config,
+    ) -> Self {
+        let lexical = if let Some(signals) = l1_signals {
+            signals.iter().map(LexicalEvidence::from_harness).collect()
+        } else if let Some(result) = l1_result {
+            result
+                .per_message_scores
+                .iter()
+                .map(LexicalEvidence::from_legacy)
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let pattern_gate = inbound_result
+            .map(|result| {
+                result
+                    .matched_patterns
+                    .iter()
+                    .map(|m| {
+                        let pattern = config.policy.block_patterns.get(m.pattern_index);
+                        PatternGateEvidence {
+                            message_index: m.message_index,
+                            role: m.role.clone(),
+                            source: m.source.clone(),
+                            action: m.action.clone(),
+                            pattern_index: m.pattern_index,
+                            category: pattern.and_then(|p| p.category.clone()),
+                            weight: pattern.map(|p| p.weight),
+                            atomic: pattern.map(|p| p.atomic),
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Self {
+            messages,
+            l0,
+            lexical,
+            payload_scan,
+            pattern_gate,
+        }
+    }
+}
+
+/// Placeholder for future first-class L0 normalization evidence.
+#[derive(Debug, Clone, PartialEq)]
+pub struct L0Evidence {
+    pub message_index: usize,
+    pub pre_char_len: usize,
+    pub post_char_len: usize,
+    pub pre_byte_len: usize,
+    pub post_byte_len: usize,
+    pub removed_control_count: usize,
+    pub removed_invisible_count: usize,
+    pub html_stripped: bool,
+    pub role_marker_neutralized_count: usize,
+}
+
+/// Lexical-classifier evidence. Rich fields are optional on the legacy path.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexicalEvidence {
+    pub message_index: usize,
+    pub role: Role,
+    pub raw_score: f64,
+    pub calibrated_score: f32,
+    pub raw_unquoted_score: Option<f64>,
+    pub raw_squash_score: Option<f64>,
+    pub unquoted_score: Option<f32>,
+    pub squash_score: Option<f32>,
+    pub quote_detected: Option<bool>,
+    pub raw_score_delta: Option<f64>,
+}
+
+impl LexicalEvidence {
+    fn from_harness(signal: &L1Signal) -> Self {
+        Self {
+            message_index: signal.message_index,
+            role: signal.role.clone(),
+            raw_score: signal.raw_score,
+            calibrated_score: signal.score,
+            raw_unquoted_score: Some(signal.raw_unquoted_score),
+            raw_squash_score: Some(signal.raw_squash_score),
+            unquoted_score: Some(signal.unquoted_score),
+            squash_score: Some(signal.squash_score),
+            quote_detected: Some(signal.quote_detected),
+            raw_score_delta: Some(signal.raw_score_delta),
+        }
+    }
+
+    fn from_legacy(score: &crate::layers::l1::L1MessageScore) -> Self {
+        Self {
+            message_index: score.message_index,
+            role: score.role.clone(),
+            raw_score: score.score,
+            calibrated_score: score.calibrated,
+            raw_unquoted_score: None,
+            raw_squash_score: None,
+            unquoted_score: None,
+            squash_score: None,
+            quote_detected: None,
+            raw_score_delta: None,
+        }
+    }
+}
+
+/// Pattern-gate evidence with config metadata resolved at construction time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PatternGateEvidence {
+    pub message_index: usize,
+    pub role: Role,
+    pub source: MatchSource,
+    pub action: PatternAction,
+    pub pattern_index: usize,
+    pub category: Option<String>,
+    pub weight: Option<f64>,
+    pub atomic: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        CompiledPattern, Config, ContentPolicy, EngineConfig, LayerConfigs, PatternAction,
+        PolicyConfig, RuntimeConfig, TrustConfig,
+    };
+    use crate::layers::l1::{L1MessageScore, L1Result, L1Verdict};
+    use crate::layers::l3_inbound::{InboundResult, InboundVerdict, PatternMatch};
+    use crate::message::Role;
+    use std::collections::HashMap;
+
+    fn config_with_patterns(patterns: Vec<CompiledPattern>) -> Config {
+        Config {
+            policy: PolicyConfig {
+                version: "v1".to_string(),
+                tools: HashMap::new(),
+                block_patterns: patterns,
+                canary_tokens: vec![],
+                sensitive_patterns: vec![],
+                untrusted_content_policy: ContentPolicy::default(),
+                trust: TrustConfig::default(),
+                layers: LayerConfigs::default(),
+            },
+            runtime: RuntimeConfig {
+                engine: EngineConfig::default(),
+                environment: "test".to_string(),
+            },
+            contract_hash: "sha256:test".to_string(),
+        }
+    }
+
+    #[test]
+    fn noop_router_returns_no_signals() {
+        let config = config_with_patterns(vec![]);
+        let messages = vec![Message::new(Role::User, "hello")];
+        let context =
+            RoutingEvidenceContext::new(&messages, None, None, None, &[], None, &config);
+        let router = NoopOrthogonalSensorRouter::new();
+        assert!(router.route(&context).is_empty());
+    }
+
+    #[test]
+    fn harness_lexical_evidence_preserves_rich_fields() {
+        let config = config_with_patterns(vec![]);
+        let messages = vec![Message::new(Role::User, "hello")];
+        let signals = vec![L1Signal {
+            message_index: 0,
+            role: Role::User,
+            raw_score: 1.2,
+            raw_unquoted_score: 0.4,
+            raw_squash_score: 1.8,
+            score: 0.7,
+            unquoted_score: 0.2,
+            squash_score: 0.9,
+            quote_detected: true,
+            raw_score_delta: 0.8,
+        }];
+
+        let context =
+            RoutingEvidenceContext::new(&messages, None, Some(&signals), None, &[], None, &config);
+
+        assert_eq!(context.lexical.len(), 1);
+        let evidence = &context.lexical[0];
+        assert_eq!(evidence.message_index, 0);
+        assert_eq!(evidence.raw_unquoted_score, Some(0.4));
+        assert_eq!(evidence.raw_squash_score, Some(1.8));
+        assert_eq!(evidence.unquoted_score, Some(0.2));
+        assert_eq!(evidence.squash_score, Some(0.9));
+        assert_eq!(evidence.quote_detected, Some(true));
+        assert_eq!(evidence.raw_score_delta, Some(0.8));
+    }
+
+    #[test]
+    fn legacy_lexical_evidence_uses_none_for_missing_fields() {
+        let config = config_with_patterns(vec![]);
+        let messages = vec![Message::new(Role::User, "hello")];
+        let result = L1Result {
+            verdict: L1Verdict::Allow,
+            per_message_scores: vec![L1MessageScore {
+                message_index: 0,
+                role: Role::User,
+                score: 1.2,
+                calibrated: 0.7,
+                specialist_name: None,
+            }],
+        };
+
+        let context =
+            RoutingEvidenceContext::new(&messages, None, None, Some(&result), &[], None, &config);
+
+        assert_eq!(context.lexical.len(), 1);
+        let evidence = &context.lexical[0];
+        assert_eq!(evidence.raw_score, 1.2);
+        assert_eq!(evidence.calibrated_score, 0.7);
+        assert_eq!(evidence.raw_unquoted_score, None);
+        assert_eq!(evidence.raw_squash_score, None);
+        assert_eq!(evidence.unquoted_score, None);
+        assert_eq!(evidence.squash_score, None);
+        assert_eq!(evidence.quote_detected, None);
+        assert_eq!(evidence.raw_score_delta, None);
+    }
+
+    #[test]
+    fn pattern_gate_metadata_is_resolved_into_context() {
+        let pattern = CompiledPattern::compile_full(
+            "ignore",
+            PatternAction::Evidence,
+            None,
+            Some("instruction_override".to_string()),
+            0.4,
+            false,
+        )
+        .unwrap();
+        let config = config_with_patterns(vec![pattern]);
+        let messages = vec![Message::new(Role::User, "ignore this")];
+        let inbound = InboundResult {
+            verdict: InboundVerdict::Allow,
+            matched_patterns: vec![PatternMatch {
+                pattern_index: 0,
+                message_index: 0,
+                role: Role::User,
+                source: MatchSource::Content,
+                action: PatternAction::Evidence,
+            }],
+        };
+
+        let context =
+            RoutingEvidenceContext::new(&messages, None, None, None, &[], Some(&inbound), &config);
+
+        assert_eq!(context.pattern_gate.len(), 1);
+        let evidence = &context.pattern_gate[0];
+        assert_eq!(evidence.category.as_deref(), Some("instruction_override"));
+        assert_eq!(evidence.weight, Some(0.4));
+        assert_eq!(evidence.atomic, Some(false));
+    }
+}

--- a/parapet/tests/integration.rs
+++ b/parapet/tests/integration.rs
@@ -22,6 +22,7 @@ use parapet::layers::l5a::L5aScanner;
 use parapet::message::Message;
 use parapet::normalize::L0Normalizer;
 use parapet::proxy::{self, Provider};
+use parapet::routing::NoopOrthogonalSensorRouter;
 use parapet::signal::combiner::DefaultVerdictCombiner;
 use parapet::signal::extractor::DefaultSignalExtractor;
 use parapet::trust::RoleTrustAssigner;
@@ -110,6 +111,7 @@ fn build_test_engine(yaml: &str, mock_url: &str) -> EngineUpstreamClient {
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor),
         verdict_combiner: Arc::new(DefaultVerdictCombiner),
         emit_l1_signals: false,
@@ -680,6 +682,7 @@ fn build_test_engine_with_http(yaml: &str, http: Arc<dyn HttpSender>) -> EngineU
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor),
         verdict_combiner: Arc::new(DefaultVerdictCombiner),
         emit_l1_signals: false,
@@ -803,6 +806,7 @@ fn build_test_engine_with_panicking_inbound(yaml: &str, mock_url: &str) -> Engin
         output_scanner: Arc::new(L5aScanner),
         session_store: None,
         multi_turn_scanner: None,
+        orthogonal_sensor_router: Arc::new(NoopOrthogonalSensorRouter::new()),
         signal_extractor: Arc::new(DefaultSignalExtractor),
         verdict_combiner: Arc::new(DefaultVerdictCombiner),
         emit_l1_signals: false,


### PR DESCRIPTION
## Summary

  - Add a no-op target-L3 routing scaffold:
    - `OrthogonalSensorRouter`
    - `NoopOrthogonalSensorRouter`
    - `RoutingEvidenceContext<'a>`
  - Build the context after PatternGate and before MultiTurnRisk.
  - Feed future `HeuristicSignal` outputs into the existing shadow combiner path.
  - Preserve current behavior: default router returns no signals.

  ## Validation

  - `cargo test routing`: 5 passed
  - `cargo test signal`: 36 passed
  - `cargo test l2a`: 98 passed
  - `cargo test engine`: 100 passed
  - `cargo test`: 783 unit tests + 12 integration tests passed
    - first sandboxed run failed only because wiremock could not bind local ports
    - rerun with escalation passed
  - `git diff --cached --check`: passed
  - `python3 scripts/check_no_data_commit.py`: passed

  ## Notes

  No sensors, no thresholds, no enforcement change, no raw content copying. This is
  only the evidence/context surface needed before target-L3 runtime work.