### PR TITLE
Bundle engine binary in Python wheel

### DIFF
--- a/parapet-py/parapet/sidecar.py
+++ b/parapet-py/parapet/sidecar.py
@@ -12,6 +12,8 @@ import atexit
 import logging
 import os
 import subprocess
+import sys
+import sysconfig
 import threading
 import time
 from dataclasses import dataclass, field
@@ -88,13 +90,20 @@ def _resolve_engine_binary(engine_bin: str | None) -> str:
     Resolution order:
       1. Explicit *engine_bin* argument.
       2. ``PARAPET_ENGINE_PATH`` environment variable.
-      3. Bare ``parapet-engine`` name (must be on ``PATH``).
+      3. Installed wheel script in the current environment.
+      4. Bare ``parapet-engine`` name (must be on ``PATH``).
     """
     if engine_bin:
         return engine_bin
     from_env = os.environ.get("PARAPET_ENGINE_PATH")
     if from_env:
         return from_env
+    executable = "parapet-engine.exe" if sys.platform == "win32" else "parapet-engine"
+    scripts_dir = sysconfig.get_path("scripts")
+    if scripts_dir:
+        installed_script = Path(scripts_dir) / executable
+        if installed_script.exists():
+            return str(installed_script)
     return "parapet-engine"
 
 

--- a/parapet-py/pyproject.toml
+++ b/parapet-py/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["maturin>=1,<2"]
+build-backend = "maturin"
 
 [project]
 name = "parapet"
@@ -19,3 +19,9 @@ dev = [
     "pytest-httpx>=0.34",
     "respx>=0.22",
 ]
+
+[tool.maturin]
+bindings = "bin"
+manifest-path = "../parapet/Cargo.toml"
+python-source = "."
+strip = true

--- a/parapet-py/tests/test_sidecar.py
+++ b/parapet-py/tests/test_sidecar.py
@@ -147,19 +147,52 @@ class TestStopEngine:
 
 
 class TestResolveEngineBinary:
-    """_resolve_engine_binary uses 3-tier fallback."""
+    """_resolve_engine_binary uses the locked 4-step fallback."""
 
     def test_explicit_arg_wins(self, monkeypatch):
         monkeypatch.setenv("PARAPET_ENGINE_PATH", "/env/parapet-engine")
+        monkeypatch.setattr("parapet.sidecar.sysconfig.get_path", lambda key: "/installed/bin")
         assert _resolve_engine_binary("/explicit/bin") == "/explicit/bin"
 
-    def test_env_var_fallback(self, monkeypatch):
+    def test_env_var_wins_over_installed_script(self, monkeypatch):
         monkeypatch.setenv("PARAPET_ENGINE_PATH", "/env/parapet-engine")
+        monkeypatch.setattr("parapet.sidecar.sysconfig.get_path", lambda key: "/installed/bin")
+        monkeypatch.setattr("parapet.sidecar.Path.exists", lambda self: True)
         assert _resolve_engine_binary(None) == "/env/parapet-engine"
+
+    def test_installed_script_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("PARAPET_ENGINE_PATH", raising=False)
+        scripts_dir = tmp_path / "bin"
+        scripts_dir.mkdir()
+        engine = scripts_dir / "parapet-engine"
+        engine.write_text("")
+        monkeypatch.setattr("parapet.sidecar.sysconfig.get_path", lambda key: str(scripts_dir))
+
+        assert _resolve_engine_binary(None) == str(engine)
+
+    def test_installed_script_missing_falls_through(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("PARAPET_ENGINE_PATH", raising=False)
+        scripts_dir = tmp_path / "bin"
+        scripts_dir.mkdir()
+        monkeypatch.setattr("parapet.sidecar.sysconfig.get_path", lambda key: str(scripts_dir))
+
+        assert _resolve_engine_binary(None) == "parapet-engine"
 
     def test_bare_name_fallback(self, monkeypatch):
         monkeypatch.delenv("PARAPET_ENGINE_PATH", raising=False)
+        monkeypatch.setattr("parapet.sidecar.sysconfig.get_path", lambda key: None)
         assert _resolve_engine_binary(None) == "parapet-engine"
+
+    def test_windows_installed_script_suffix(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("PARAPET_ENGINE_PATH", raising=False)
+        scripts_dir = tmp_path / "Scripts"
+        scripts_dir.mkdir()
+        engine = scripts_dir / "parapet-engine.exe"
+        engine.write_text("")
+        monkeypatch.setattr("parapet.sidecar.sys.platform", "win32")
+        monkeypatch.setattr("parapet.sidecar.sysconfig.get_path", lambda key: str(scripts_dir))
+
+        assert _resolve_engine_binary(None) == str(engine)
 
 
 class TestEngineBinaryNotFound:


### PR DESCRIPTION
  Validation passed:

  - 12 passed for tests/test_sidecar.py
  - 88 passed for Python SDK non-E2E tests
  - check_no_data_commit.py passed
  - smoke install resolved _resolve_engine_binary(None) to the
    venv parapet-engine
