### PR TITLE
Add P3 embedding-distance D_eval member + hand-rolled MLX encoder backend

### DIFF
--- a/parapet-data/parapet_data/p3/detectors/deval_embed.py
+++ b/parapet-data/parapet_data/p3/detectors/deval_embed.py
@@ -1,0 +1,172 @@
+"""D_eval member: embedding-distance retrieval detector (embedding family).
+
+Scores a per-event surface_signal as the calibrated max cosine similarity of the
+event-span embedding to a reference set of known control-plane payloads (mined from
+carrier injections + the MHJ control-plane minority + handcrafted; see
+detector_ensemble_spec.md section 3). Intuition: an event that reads like a known
+control-plane move sits close in embedding space to the reference payloads; a benign
+event sits far. This is the retrieval-family foil in the cross-family D_eval ensemble.
+
+Backend-agnostic: the embedding model is INJECTED as embed_fn(texts) -> list[vector]
+(mirrors deval_l1.run_fn and mlx_judge.complete_fn). This keeps the member testable
+with a deterministic fake embedder and lets the concrete MLX-native backend be chosen
+separately.
+
+Scouting note (2026-06-06): there is no clean lightweight MLX-native embedding package.
+mlx_lm has no embeddings; mlx-embeddings is torch-free but pulls mlx-vlm (+ datasets,
+opencv, audio, fastapi), which AGENTS.md says to defer; sentence-transformers pulls
+torch (deferred fallback). The clean route is a hand-rolled mlx encoder (mlx +
+safetensors + the present transformers tokenizer, no new deps). The backend is an
+author decision, so this module never imports it: callers pass embed_fn.
+
+FAILS CLOSED: an embed_fn error, a wrong return count, a zero vector, or a dim mismatch
+yields error DetectorResults (score=None), never a silent 0.0.
+
+Calibration: cosine similarity in [-1,1] -> surface_signal in [0,1] via the in-tree
+sigmoid (constants below). Provisional; final values come from the tau_event
+calibration sweep (detector_ensemble_spec.md section 6).
+"""
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional, Sequence
+
+from parapet_data.p3.detectors.interface import (
+    FAMILY_EMBEDDING,
+    DetectorResult,
+    EventContext,
+    clamp_unit,
+)
+
+# Calibrated on the tau_event calibration batch (section 6); provisional defaults.
+# P = 1 / (1 + exp(-A * (max_cos - B))). B ~ the benign/attack cosine crossover,
+# A the sharpness. Update both once the calibration sweep picks them.
+EMBED_SIGMOID_A = 12.0
+EMBED_SIGMOID_B = 0.5
+
+DETECTOR_ID = "deval_embed_cos"
+DEFAULT_MODEL_ID = "mlx-embed-unset"
+
+# embed_fn maps a sequence of texts to a same-length sequence of equal-length vectors.
+EmbedFn = Callable[[Sequence[str]], Sequence[Sequence[float]]]
+
+
+def calibrate(max_cos: float) -> float:
+    """Max cosine similarity in [-1,1] -> [0,1] via the in-tree sigmoid (constants above)."""
+    return clamp_unit(1.0 / (1.0 + math.exp(-EMBED_SIGMOID_A * (max_cos - EMBED_SIGMOID_B))))
+
+
+def _l2_normalize(vec: Sequence[float]) -> Optional[list]:
+    """Return the unit-norm vector as a list of floats, or None for a zero/empty vector."""
+    try:
+        floats = [float(x) for x in vec]
+    except (TypeError, ValueError):
+        return None
+    if not floats:
+        return None
+    norm = math.sqrt(sum(x * x for x in floats))
+    if norm == 0.0:
+        return None
+    return [x / norm for x in floats]
+
+
+class DEvalEmbed:
+    family = FAMILY_EMBEDDING
+    detector_id = DETECTOR_ID
+
+    def __init__(
+        self,
+        *,
+        embed_fn: EmbedFn,
+        reference_texts: Sequence[str],
+        model_id: str = DEFAULT_MODEL_ID,
+    ):
+        if embed_fn is None:
+            raise ValueError("embed_fn is required")
+        refs = [t for t in (reference_texts or []) if t and str(t).strip()]
+        if not refs:
+            raise ValueError("reference_texts must be non-empty (control-plane payload set)")
+        self.embed_fn = embed_fn
+        self.model_id = model_id
+        # Embed + normalize the reference set ONCE at construction. A backend failure
+        # here is a misconfiguration, not a per-event error: fail loud.
+        ref_vecs = list(embed_fn(refs))
+        if len(ref_vecs) != len(refs):
+            raise ValueError(
+                f"embed_fn returned {len(ref_vecs)} vectors for {len(refs)} reference texts"
+            )
+        normed = []
+        for v in ref_vecs:
+            nv = _l2_normalize(v)
+            if nv is None:
+                raise ValueError("embed_fn produced an empty or zero reference vector")
+            normed.append(nv)
+        self._ref = normed
+        self._dim = len(normed[0])
+        if any(len(v) != self._dim for v in normed):
+            raise ValueError("reference embeddings have inconsistent dimensions")
+
+    def _result(self, score, error, rationale=None) -> DetectorResult:
+        return DetectorResult(
+            score=score, family=self.family, model_id=self.model_id,
+            detector_id=self.detector_id, rationale=rationale, error=error,
+        )
+
+    def _max_cos(self, qn: list) -> float:
+        """Max cosine similarity of a unit-norm query to the unit-norm reference set."""
+        best = -1.0
+        for r in self._ref:
+            dot = 0.0
+            for a, b in zip(qn, r):
+                dot += a * b
+            if dot > best:
+                best = dot
+        return best
+
+    def score(self, event_text: str, context: Optional[EventContext] = None) -> DetectorResult:
+        return self.score_batch([event_text], [context])[0]
+
+    def score_batch(self, texts: list, contexts=None) -> list:
+        n = len(texts)
+        results: list = [None] * n
+        # Empty texts never reach the backend; mirror the L1/judge empty handling.
+        send_idx = []
+        for i, t in enumerate(texts):
+            if not t or not str(t).strip():
+                results[i] = self._result(None, "empty_event_text")
+            else:
+                send_idx.append(i)
+        if not send_idx:
+            return results
+
+        try:
+            vecs = list(self.embed_fn([texts[i] for i in send_idx]))
+        except Exception as exc:  # backend is arbitrary; fail closed, do not crash the run
+            return self._fill(results, send_idx, f"embed_failed: {type(exc).__name__}")
+
+        if len(vecs) != len(send_idx):
+            return self._fill(
+                results, send_idx,
+                f"embed_count_mismatch: got {len(vecs)} for {len(send_idx)}",
+            )
+
+        for pos, i in enumerate(send_idx):
+            qn = _l2_normalize(vecs[pos])
+            if qn is None:
+                results[i] = self._result(None, "embed_zero_vector")
+            elif len(qn) != self._dim:
+                results[i] = self._result(
+                    None, f"embed_dim_mismatch: {len(qn)} != ref {self._dim}",
+                )
+            else:
+                max_cos = self._max_cos(qn)
+                results[i] = self._result(
+                    calibrate(max_cos), None,
+                    rationale=f"max cosine {max_cos:.4f} over {len(self._ref)} refs",
+                )
+        return results
+
+    def _fill(self, results: list, idxs: list, error: str) -> list:
+        for i in idxs:
+            results[i] = self._result(None, error)
+        return results

--- a/parapet-data/parapet_data/p3/detectors/mlx_embed_backend.py
+++ b/parapet-data/parapet_data/p3/detectors/mlx_embed_backend.py
@@ -1,0 +1,270 @@
+"""Hand-rolled MLX-native encoder backend for the embedding-distance D_eval member.
+
+Provides a concrete `embed_fn` for `deval_embed.DEvalEmbed` by running a small
+BGE/E5-style BERT encoder in MLX. No torch, no sentence-transformers, no mlx-vlm:
+just `mlx` + `safetensors` (via mlx's loader) + the already-present `transformers`
+tokenizer. This is the author-chosen clean backend (see detector_ensemble_spec.md
+section 7 scouting note).
+
+Design / guardrails:
+- mlx and transformers are imported LAZILY (inside the class), so importing this module
+  never requires them. The pooling/normalization math is pure numpy and unit-testable
+  with no mlx, no weights, no network.
+- An explicit local model path (a directory) is REQUIRED. A bare repo id is only
+  fetched when allow_download=True; otherwise a clear error is raised. Nothing is ever
+  silently downloaded.
+- Tokenizer loads local_files_only unless allow_download=True.
+
+Scope: BERT-convention encoders (positions 0..L-1, learned position embeddings),
+which covers bge-small-en-v1.5 and e5-small-v2. XLM-RoBERTa-based encoders (e.g.
+multilingual-e5) use a position offset and are out of scope for this adapter; point it
+at a BERT-based encoder.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+from typing import Callable, Optional, Sequence
+
+import numpy as np
+
+POOL_MEAN = "mean"
+POOL_CLS = "cls"
+
+# Standard HF BERT weight-key template (no prefix). _resolve_prefix() also tries "bert.".
+_K = {
+    "word": "embeddings.word_embeddings.weight",
+    "pos": "embeddings.position_embeddings.weight",
+    "tok_type": "embeddings.token_type_embeddings.weight",
+    "emb_ln_w": "embeddings.LayerNorm.weight",
+    "emb_ln_b": "embeddings.LayerNorm.bias",
+}
+
+
+def _layer_keys(prefix: str, i: int) -> dict:
+    p = f"{prefix}encoder.layer.{i}."
+    return {
+        "q_w": p + "attention.self.query.weight", "q_b": p + "attention.self.query.bias",
+        "k_w": p + "attention.self.key.weight", "k_b": p + "attention.self.key.bias",
+        "v_w": p + "attention.self.value.weight", "v_b": p + "attention.self.value.bias",
+        "ao_w": p + "attention.output.dense.weight", "ao_b": p + "attention.output.dense.bias",
+        "aln_w": p + "attention.output.LayerNorm.weight", "aln_b": p + "attention.output.LayerNorm.bias",
+        "im_w": p + "intermediate.dense.weight", "im_b": p + "intermediate.dense.bias",
+        "out_w": p + "output.dense.weight", "out_b": p + "output.dense.bias",
+        "oln_w": p + "output.LayerNorm.weight", "oln_b": p + "output.LayerNorm.bias",
+    }
+
+
+# ---- pure numpy helpers (no mlx; the bug-prone bits, unit-tested directly) ----
+
+def mean_pool(last_hidden: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+    """Mask-aware mean over tokens. last_hidden: (B,L,H), mask: (B,L) -> (B,H)."""
+    mask = attention_mask.astype(last_hidden.dtype)[:, :, None]  # (B,L,1)
+    summed = (last_hidden * mask).sum(axis=1)                    # (B,H)
+    counts = np.clip(mask.sum(axis=1), 1e-9, None)               # (B,1)
+    return summed / counts
+
+
+def cls_pool(last_hidden: np.ndarray) -> np.ndarray:
+    """First-token ([CLS]) pooling. last_hidden: (B,L,H) -> (B,H)."""
+    return last_hidden[:, 0, :]
+
+
+def l2_normalize_rows(mat: np.ndarray) -> np.ndarray:
+    """Row-wise L2 normalize. Zero rows stay zero (caller fails closed downstream)."""
+    norms = np.sqrt((mat * mat).sum(axis=1, keepdims=True))
+    norms = np.where(norms == 0.0, 1.0, norms)
+    return mat / norms
+
+
+class MLXEncoder:
+    """A small BERT-convention encoder run in MLX. Loads config + safetensors weights."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        pooling: str = POOL_MEAN,
+        allow_download: bool = False,
+        max_length: int = 512,
+    ):
+        if pooling not in (POOL_MEAN, POOL_CLS):
+            raise ValueError(f"pooling must be '{POOL_MEAN}' or '{POOL_CLS}', got {pooling!r}")
+        self.pooling = pooling
+        self.allow_download = allow_download
+        self.max_length = max_length
+        self.model_dir = self._resolve_model_dir(model_path, allow_download)
+
+        cfg = json.loads(self._read(os.path.join(self.model_dir, "config.json")))
+        self.hidden = int(cfg["hidden_size"])
+        self.n_layers = int(cfg["num_hidden_layers"])
+        self.n_heads = int(cfg["num_attention_heads"])
+        self.head_dim = self.hidden // self.n_heads
+        self.eps = float(cfg.get("layer_norm_eps", 1e-12))
+        if self.hidden % self.n_heads != 0:
+            raise ValueError("hidden_size not divisible by num_attention_heads")
+
+        self._mx = self._import_mx()
+        self._w = self._load_weights()
+        self._tokenizer = None  # lazy: embed_token_batch never needs it
+
+    # -- resolution / IO --
+
+    @staticmethod
+    def _resolve_model_dir(model_path: str, allow_download: bool) -> str:
+        if os.path.isdir(model_path):
+            return model_path
+        if not allow_download:
+            raise ValueError(
+                f"model_path {model_path!r} is not a local directory and allow_download=False. "
+                "Pass a local encoder dir, or set allow_download=True to fetch a repo id."
+            )
+        from huggingface_hub import snapshot_download  # lazy
+        return snapshot_download(model_path)
+
+    @staticmethod
+    def _read(path: str) -> str:
+        with open(path) as fh:
+            return fh.read()
+
+    @staticmethod
+    def _import_mx():
+        import mlx.core as mx  # lazy: module imports fine without mlx
+        return mx
+
+    def _safetensors_path(self) -> str:
+        for name in ("model.safetensors", "pytorch_model.safetensors"):
+            cand = os.path.join(self.model_dir, name)
+            if os.path.isfile(cand):
+                return cand
+        raise FileNotFoundError(f"no model.safetensors in {self.model_dir}")
+
+    def _resolve_prefix(self, keys) -> str:
+        if _K["word"] in keys:
+            return ""
+        if "bert." + _K["word"] in keys:
+            return "bert."
+        raise KeyError(
+            f"could not find {_K['word']} (with or without 'bert.' prefix) in weights; "
+            "is this a BERT-convention encoder?"
+        )
+
+    def _load_weights(self) -> dict:
+        raw = self._mx.load(self._safetensors_path())  # dict[str, mx.array]
+        prefix = self._resolve_prefix(raw)
+        w = {k: raw[prefix + v] for k, v in _K.items()}
+        w["layers"] = [
+            {k: raw[name] for k, name in _layer_keys(prefix, i).items()}
+            for i in range(self.n_layers)
+        ]
+        return w
+
+    # -- mlx forward --
+
+    def _ln(self, x, weight, bias):
+        mx = self._mx
+        mu = x.mean(axis=-1, keepdims=True)
+        var = ((x - mu) ** 2).mean(axis=-1, keepdims=True)
+        return (x - mu) / mx.sqrt(var + self.eps) * weight + bias
+
+    def _linear(self, x, w, b):
+        return x @ w.T + b  # HF linear weight is (out,in); y = x W^T + b
+
+    def _gelu(self, x):
+        return 0.5 * x * (1.0 + self._mx.erf(x / math.sqrt(2.0)))
+
+    def _attention(self, x, lw, add_mask):
+        mx = self._mx
+        b, l, _ = x.shape
+        h, d = self.n_heads, self.head_dim
+
+        def heads(t):
+            return t.reshape(b, l, h, d).transpose(0, 2, 1, 3)  # (B,H,L,d)
+
+        q = heads(self._linear(x, lw["q_w"], lw["q_b"]))
+        k = heads(self._linear(x, lw["k_w"], lw["k_b"]))
+        v = heads(self._linear(x, lw["v_w"], lw["v_b"]))
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(d)
+        scores = scores + add_mask  # (B,1,1,L) additive, -inf on pad
+        probs = mx.softmax(scores, axis=-1)
+        ctx = (probs @ v).transpose(0, 2, 1, 3).reshape(b, l, h * d)
+        attn = self._linear(ctx, lw["ao_w"], lw["ao_b"])
+        return self._ln(x + attn, lw["aln_w"], lw["aln_b"])
+
+    def _layer(self, x, lw, add_mask):
+        x = self._attention(x, lw, add_mask)
+        h = self._gelu(self._linear(x, lw["im_w"], lw["im_b"]))
+        out = self._linear(h, lw["out_w"], lw["out_b"])
+        return self._ln(x + out, lw["oln_w"], lw["oln_b"])
+
+    def forward(self, input_ids: np.ndarray, attention_mask: np.ndarray):
+        """Run the encoder. Returns last_hidden_state as a numpy array (B,L,H)."""
+        mx = self._mx
+        w = self._w
+        ids = mx.array(np.asarray(input_ids, dtype=np.int32))
+        b, l = ids.shape
+        pos = mx.arange(l).reshape(1, l)
+        emb = w["word"][ids] + w["pos"][pos] + w["tok_type"][mx.zeros((1, l), dtype=mx.int32)]
+        x = self._ln(emb, w["emb_ln_w"], w["emb_ln_b"])
+        # additive mask: 0 where attend, large-negative where pad -> (B,1,1,L)
+        m = mx.array(np.asarray(attention_mask, dtype=np.float32))
+        add_mask = (1.0 - m).reshape(b, 1, 1, l) * -1e9
+        for lw in w["layers"]:
+            x = self._layer(x, lw, add_mask)
+        mx.eval(x)
+        return np.array(x)
+
+    # -- public embedding API --
+
+    def embed_token_batch(self, input_ids, attention_mask=None) -> list:
+        """Forward + pool + L2-normalize pre-tokenized ids. Returns list[list[float]]."""
+        ids = np.asarray(input_ids, dtype=np.int64)
+        if ids.ndim != 2:
+            raise ValueError("input_ids must be 2-d (batch, seq)")
+        mask = (np.ones_like(ids) if attention_mask is None
+                else np.asarray(attention_mask)).astype(np.int64)
+        hidden = self.forward(ids, mask)
+        pooled = mean_pool(hidden, mask) if self.pooling == POOL_MEAN else cls_pool(hidden)
+        return l2_normalize_rows(pooled).astype(np.float64).tolist()
+
+    def _tok(self):
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer  # lazy
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                self.model_dir, local_files_only=not self.allow_download
+            )
+        return self._tokenizer
+
+    def embed(self, texts: Sequence[str]) -> list:
+        enc = self._tok()(
+            list(texts), padding=True, truncation=True,
+            max_length=self.max_length, return_tensors=None,
+        )
+        return self.embed_token_batch(enc["input_ids"], enc["attention_mask"])
+
+
+def make_mlx_embed_fn(
+    model_path: str,
+    *,
+    pooling: str = POOL_MEAN,
+    allow_download: bool = False,
+    max_length: int = 512,
+    batch_size: int = 32,
+) -> Callable[[Sequence[str]], list]:
+    """Build an embed_fn(texts) -> list[vector] for DEvalEmbed, backed by an MLX encoder.
+
+    model_path: a LOCAL encoder directory (config.json + model.safetensors + tokenizer),
+    or a repo id only if allow_download=True. Nothing is downloaded otherwise.
+    """
+    enc = MLXEncoder(model_path, pooling=pooling, allow_download=allow_download,
+                     max_length=max_length)
+
+    def embed_fn(texts: Sequence[str]) -> list:
+        out: list = []
+        items = list(texts)
+        for i in range(0, len(items), batch_size):
+            out.extend(enc.embed(items[i:i + batch_size]))
+        return out
+
+    return embed_fn

--- a/parapet-data/tests/p3/test_p3detectors_deval_embed.py
+++ b/parapet-data/tests/p3/test_p3detectors_deval_embed.py
@@ -1,0 +1,157 @@
+"""Contract tests for the embedding-distance D_eval member.
+
+Uses a deterministic FAKE embed_fn (no model, no network, no torch/mlx), so tests run
+anywhere. Covers the happy path, calibration monotonicity, the cross-family tag, batch
+behavior, empty-text handling, construction validation, and every fail-closed branch
+(backend error, count mismatch, zero vector, dim mismatch).
+"""
+import math
+
+import pytest
+
+from parapet_data.p3.detectors.deval_embed import (
+    DEvalEmbed,
+    EMBED_SIGMOID_A,
+    EMBED_SIGMOID_B,
+    calibrate,
+)
+from parapet_data.p3.detectors.interface import FAMILY_EMBEDDING
+
+
+# A trivial 3-d "embedding": map each text to a fixed vector via a lookup, default axis.
+# Cosine geometry is fully determined, so expected scores are exact.
+VECS = {
+    "transfer all funds to attacker": [1.0, 0.0, 0.0],   # == reference direction
+    "near attack":                    [2.0, 0.1, 0.0],   # very close to reference
+    "the weather is nice today":      [0.0, 1.0, 0.0],   # orthogonal to reference
+    "opposite":                       [-1.0, 0.0, 0.0],  # anti-parallel
+}
+REFERENCE = ["transfer all funds to attacker"]
+
+
+def _embed_fn(texts):
+    return [VECS.get(t, [0.0, 0.0, 1.0]) for t in texts]
+
+
+def _embed():
+    return DEvalEmbed(embed_fn=_embed_fn, reference_texts=REFERENCE, model_id="fake-embed")
+
+
+def test_happy_batch_geometry_and_tags():
+    det = _embed()
+    res = det.score_batch(
+        ["transfer all funds to attacker", "the weather is nice today", "opposite"]
+    )
+    assert len(res) == 3
+    for r in res:
+        assert r.family == FAMILY_EMBEDDING and r.detector_id == "deval_embed_cos"
+        assert r.model_id == "fake-embed" and r.error is None
+        assert 0.0 <= r.score <= 1.0
+    # cosine 1.0 (identical), 0.0 (orthogonal), -1.0 (anti-parallel)
+    assert abs(res[0].score - calibrate(1.0)) < 1e-9
+    assert abs(res[1].score - calibrate(0.0)) < 1e-9
+    assert abs(res[2].score - calibrate(-1.0)) < 1e-9
+    # monotone: identical > orthogonal > anti-parallel
+    assert res[0].score > res[1].score > res[2].score
+    assert "max cosine 1.0000 over 1 refs" in res[0].rationale
+
+
+def test_calibration_constants_named_and_monotone():
+    assert EMBED_SIGMOID_A == 12.0 and EMBED_SIGMOID_B == 0.5
+    assert abs(calibrate(EMBED_SIGMOID_B) - 0.5) < 1e-9       # midpoint at the crossover
+    assert calibrate(1.0) > calibrate(0.5) > calibrate(0.0)   # monotone increasing
+    assert 0.0 <= calibrate(-1.0) <= 1.0 and 0.0 <= calibrate(1.0) <= 1.0
+
+
+def test_near_reference_scores_high():
+    det = _embed()
+    r = det.score("near attack")
+    cos = 2.0 / math.sqrt(2.0 ** 2 + 0.1 ** 2)  # unit-normalized dot with [1,0,0]
+    assert abs(r.score - calibrate(cos)) < 1e-9
+    assert r.score > 0.9  # close to the control-plane reference -> high surface_signal
+
+
+def test_score_single_routes_through_batch():
+    det = _embed()
+    r = det.score("the weather is nice today")
+    assert r.error is None and abs(r.score - calibrate(0.0)) < 1e-9
+
+
+def test_empty_text_skipped_others_scored():
+    det = _embed()
+    res = det.score_batch(["   ", "transfer all funds to attacker"])
+    assert res[0].score is None and res[0].error == "empty_event_text"
+    assert res[1].error is None and abs(res[1].score - calibrate(1.0)) < 1e-9
+
+
+def test_all_empty_skips_backend():
+    calls = []
+
+    def embed_fn(texts):
+        calls.append(list(texts))
+        return [[1.0, 0.0, 0.0]] * len(texts)
+
+    det = DEvalEmbed(embed_fn=embed_fn, reference_texts=REFERENCE)
+    calls.clear()  # ignore the construction-time reference embed call
+    res = det.score_batch(["", "  "])
+    assert all(r.error == "empty_event_text" for r in res)
+    assert calls == []  # backend never invoked for the empty batch
+
+
+def test_backend_error_fails_closed():
+    def embed_fn(texts):
+        if texts == REFERENCE:
+            return [[1.0, 0.0, 0.0]]
+        raise RuntimeError("backend down")
+
+    det = DEvalEmbed(embed_fn=embed_fn, reference_texts=REFERENCE)
+    res = det.score_batch(["x", "y"])
+    assert all(r.score is None and r.error.startswith("embed_failed: RuntimeError") for r in res)
+
+
+def test_count_mismatch_fails_closed():
+    def embed_fn(texts):
+        if texts == REFERENCE:
+            return [[1.0, 0.0, 0.0]]
+        return [[1.0, 0.0, 0.0]]  # one vector regardless of how many texts
+
+    det = DEvalEmbed(embed_fn=embed_fn, reference_texts=REFERENCE)
+    res = det.score_batch(["a", "b"])
+    assert all(r.score is None and r.error.startswith("embed_count_mismatch") for r in res)
+
+
+def test_zero_vector_fails_closed():
+    def embed_fn(texts):
+        if texts == REFERENCE:
+            return [[1.0, 0.0, 0.0]]
+        return [[0.0, 0.0, 0.0] for _ in texts]
+
+    det = DEvalEmbed(embed_fn=embed_fn, reference_texts=REFERENCE)
+    res = det.score_batch(["x"])
+    assert res[0].score is None and res[0].error == "embed_zero_vector"
+
+
+def test_dim_mismatch_fails_closed():
+    def embed_fn(texts):
+        if texts == REFERENCE:
+            return [[1.0, 0.0, 0.0]]
+        return [[1.0, 0.0] for _ in texts]  # 2-d query vs 3-d reference
+
+    det = DEvalEmbed(embed_fn=embed_fn, reference_texts=REFERENCE)
+    res = det.score_batch(["x"])
+    assert res[0].score is None and res[0].error.startswith("embed_dim_mismatch")
+
+
+def test_construction_requires_reference():
+    with pytest.raises(ValueError):
+        DEvalEmbed(embed_fn=_embed_fn, reference_texts=[])
+    with pytest.raises(ValueError):
+        DEvalEmbed(embed_fn=_embed_fn, reference_texts=["   "])
+
+
+def test_construction_rejects_zero_reference_vector():
+    def embed_fn(texts):
+        return [[0.0, 0.0, 0.0] for _ in texts]
+
+    with pytest.raises(ValueError):
+        DEvalEmbed(embed_fn=embed_fn, reference_texts=["something"])

--- a/parapet-data/tests/p3/test_p3detectors_mlx_embed_backend.py
+++ b/parapet-data/tests/p3/test_p3detectors_mlx_embed_backend.py
@@ -1,0 +1,152 @@
+"""Tests for the hand-rolled MLX encoder backend.
+
+Two layers:
+- Pure numpy pooling/normalization helpers (need numpy, not mlx): mask-aware mean,
+  cls, L2 normalize. These are the bug-prone bits.
+- A tiny SYNTHETIC-WEIGHTS encoder (needs mlx): random weights saved to safetensors in
+  a tmp dir, loaded through MLXEncoder, asserting forward shape, unit-norm output, and
+  mean-vs-cls pooling difference. No weights are ever downloaded.
+
+Imports are deferred behind importorskip so the light `uv run --with-editable
+parapet-data` env (no numpy/mlx) skips this file cleanly instead of erroring.
+"""
+import json
+import os
+
+import pytest
+
+
+# ---- pure numpy helpers (no mlx) ----
+
+def test_mean_pool_is_mask_aware():
+    np = pytest.importorskip("numpy")
+    from parapet_data.p3.detectors.mlx_embed_backend import mean_pool
+    hidden = np.array([[[1.0, 1.0], [3.0, 3.0], [9.0, 9.0]]])  # (1,3,2)
+    mask = np.array([[1, 1, 0]])                               # last token padded
+    pooled = mean_pool(hidden, mask)
+    assert pooled.shape == (1, 2)
+    assert np.allclose(pooled, [[2.0, 2.0]])  # mean of first two only, pad ignored
+
+
+def test_cls_pool_takes_first_token():
+    np = pytest.importorskip("numpy")
+    from parapet_data.p3.detectors.mlx_embed_backend import cls_pool
+    hidden = np.array([[[7.0, 8.0], [1.0, 1.0]]])  # (1,2,2)
+    assert np.allclose(cls_pool(hidden), [[7.0, 8.0]])
+
+
+def test_l2_normalize_rows_unit_norm_and_zero_safe():
+    np = pytest.importorskip("numpy")
+    from parapet_data.p3.detectors.mlx_embed_backend import l2_normalize_rows
+    mat = np.array([[3.0, 4.0], [0.0, 0.0]])
+    out = l2_normalize_rows(mat)
+    assert np.allclose(np.sqrt((out[0] ** 2).sum()), 1.0)  # 3-4-5 -> unit
+    assert np.allclose(out[1], [0.0, 0.0])                 # zero row stays zero, no nan
+
+
+# ---- model-path gate (needs numpy for module import, not mlx) ----
+
+def test_requires_local_dir_or_download():
+    pytest.importorskip("numpy")
+    from parapet_data.p3.detectors.mlx_embed_backend import MLXEncoder, make_mlx_embed_fn
+    with pytest.raises(ValueError, match="allow_download"):
+        MLXEncoder("/no/such/encoder/dir", allow_download=False)
+    with pytest.raises(ValueError, match="allow_download"):
+        make_mlx_embed_fn("some/repo-id", allow_download=False)
+
+
+# ---- synthetic-weights encoder (needs mlx; no downloads) ----
+
+def _write_synthetic_model(mx, np, model_dir, *, hidden=8, layers=2, heads=2,
+                           inter=16, vocab=20, max_pos=16, type_vocab=2):
+    cfg = {
+        "hidden_size": hidden, "num_hidden_layers": layers,
+        "num_attention_heads": heads, "intermediate_size": inter,
+        "vocab_size": vocab, "max_position_embeddings": max_pos,
+        "type_vocab_size": type_vocab, "layer_norm_eps": 1e-12, "hidden_act": "gelu",
+    }
+    with open(os.path.join(model_dir, "config.json"), "w") as fh:
+        json.dump(cfg, fh)
+
+    rng = np.random.default_rng(0)
+
+    def rnd(*shape):
+        return mx.array((rng.standard_normal(shape) * 0.02).astype(np.float32))
+
+    def ln_w(n):  # LayerNorm: ones weight, zero bias (stable, still exercises the path)
+        return mx.array(np.ones(n, dtype=np.float32))
+
+    def ln_b(n):
+        return mx.array(np.zeros(n, dtype=np.float32))
+
+    w = {
+        "embeddings.word_embeddings.weight": rnd(vocab, hidden),
+        "embeddings.position_embeddings.weight": rnd(max_pos, hidden),
+        "embeddings.token_type_embeddings.weight": rnd(type_vocab, hidden),
+        "embeddings.LayerNorm.weight": ln_w(hidden),
+        "embeddings.LayerNorm.bias": ln_b(hidden),
+    }
+    for i in range(layers):
+        p = f"encoder.layer.{i}."
+        w.update({
+            p + "attention.self.query.weight": rnd(hidden, hidden),
+            p + "attention.self.query.bias": ln_b(hidden),
+            p + "attention.self.key.weight": rnd(hidden, hidden),
+            p + "attention.self.key.bias": ln_b(hidden),
+            p + "attention.self.value.weight": rnd(hidden, hidden),
+            p + "attention.self.value.bias": ln_b(hidden),
+            p + "attention.output.dense.weight": rnd(hidden, hidden),
+            p + "attention.output.dense.bias": ln_b(hidden),
+            p + "attention.output.LayerNorm.weight": ln_w(hidden),
+            p + "attention.output.LayerNorm.bias": ln_b(hidden),
+            p + "intermediate.dense.weight": rnd(inter, hidden),
+            p + "intermediate.dense.bias": ln_b(inter),
+            p + "output.dense.weight": rnd(hidden, inter),
+            p + "output.dense.bias": ln_b(hidden),
+            p + "output.LayerNorm.weight": ln_w(hidden),
+            p + "output.LayerNorm.bias": ln_b(hidden),
+        })
+    mx.save_safetensors(os.path.join(model_dir, "model.safetensors"), w)
+    return hidden
+
+
+def test_synthetic_encoder_forward_shape_and_pooling(tmp_path):
+    mx = pytest.importorskip("mlx.core")
+    np = pytest.importorskip("numpy")
+    from parapet_data.p3.detectors.mlx_embed_backend import MLXEncoder
+
+    model_dir = str(tmp_path)
+    hidden = _write_synthetic_model(mx, np, model_dir)
+
+    ids = [[2, 5, 7, 3, 0], [4, 6, 1, 0, 0]]
+    mask = [[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]]
+
+    enc_mean = MLXEncoder(model_dir, pooling="mean")
+    hid = enc_mean.forward(np.array(ids), np.array(mask))
+    assert hid.shape == (2, 5, hidden)  # (B, L, H)
+
+    vecs = enc_mean.embed_token_batch(ids, mask)
+    assert len(vecs) == 2 and all(len(v) == hidden for v in vecs)
+    for v in vecs:
+        assert abs(sum(x * x for x in v) - 1.0) < 1e-5  # L2-normalized output
+
+    enc_cls = MLXEncoder(model_dir, pooling="cls")
+    vecs_cls = enc_cls.embed_token_batch(ids, mask)
+    # mean and cls pooling must produce different embeddings for the same input
+    assert any(abs(a - b) > 1e-4 for a, b in zip(vecs[0], vecs_cls[0]))
+
+
+def test_synthetic_encoder_masking_changes_output(tmp_path):
+    mx = pytest.importorskip("mlx.core")
+    np = pytest.importorskip("numpy")
+    from parapet_data.p3.detectors.mlx_embed_backend import MLXEncoder
+
+    model_dir = str(tmp_path)
+    _write_synthetic_model(mx, np, model_dir)
+    enc = MLXEncoder(model_dir, pooling="mean")
+
+    ids = [[2, 5, 7, 3, 9]]
+    full = enc.embed_token_batch(ids, [[1, 1, 1, 1, 1]])
+    masked = enc.embed_token_batch(ids, [[1, 1, 1, 0, 0]])
+    # dropping real tokens from the mask must change the pooled embedding
+    assert any(abs(a - b) > 1e-4 for a, b in zip(full[0], masked[0]))


### PR DESCRIPTION
Adds the embedding-distance D_eval member for the Paper-3 detector ensemble, plus its
hand-rolled MLX encoder backend (author-chosen over mlx-embeddings, which pulls the
AGENTS.md-deferred mlx-vlm tree).

Commits:
- Embedding member (deval_embed.py): calibrated max cosine similarity of an event
embedding to a reference set of control-plane payloads. Backend-injected (embed_fn),
family=embedding, fail-closed. 12 contract tests with a fake embedder.
- MLX backend (mlx_embed_backend.py): small BGE/E5-style BERT encoder on mlx +
safetensors + the transformers tokenizer. No torch / sentence-transformers / mlx-vlm.
Lazy heavy imports; pure-numpy pooling math; explicit local model dir required, repo
fetched only with allow_download=True.

Verification:
- Unit: 66 passed + 6 skipped (light env); 6 passed with mlx (synthetic-weights forward).
- Live e2e (bge-small-en-v1.5, local): paraphrase 0.869 vs unrelated 0.346 (forward is
numerically correct), member separates attack 0.959 vs benign 0.259. No torch.