### PR TITLE
Add Phase-1 effect-event taxonomy (intrinsic-severity abstraction)

### DIFF
--- a/parapet-data/parapet_data/effects/__init__.py
+++ b/parapet-data/parapet_data/effects/__init__.py
@@ -1,0 +1,6 @@
+"""Phase-1 effect-event taxonomy (intrinsic-severity abstraction).
+
+Content-safe public subpackage: the kind map, doc-sourced extractor registry,
+intrinsic-severity function g, and identity-free friction gate. Carries no
+benchmark data; exercised by synthetic-fixture tests under tests/effects/.
+"""

--- a/parapet-data/parapet_data/effects/effect_taxonomy.py
+++ b/parapet-data/parapet_data/effects/effect_taxonomy.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""Phase-1 effect-event taxonomy as a tested abstraction.
+
+Implements the converged design:
+  * effect_event_taxonomy.md v2.2 (kind map + precedence + extractor registry +
+    orthogonal axes + observability tags + the two schemas)
+  * effect_severity_rubric.md v1.1 (g = intrinsic_effect_severity over MECHANICAL
+    FACTS ONLY, plus the identity-free FRICTION gate)
+
+DISCIPLINE (binding, from the design):
+  * The extractor REGISTRY is authored ONLY from the AgentDojo tool schemas/docs
+    (function signatures + docstrings), NEVER from benchmark labels, outcome data,
+    or failure analysis. Each arg_name -> payload_field mapping is directly
+    supported by the tool's own doc text (registry-as-code rule).
+  * `g` reads ONLY mechanical fact fields (effect_kind, payloads,
+    availability_impact[mechanical], sink_visibility, reversibility,
+    data_sensitivity). It NEVER reads authorization, recipient_identity_class,
+    or principal.
+  * The registry is HASH-FROZEN (REGISTRY_FROZEN_SHA256) before any scoring run.
+  * `ambiguous` / UNKNOWN severity is first-class: it routes to the friction /
+    confirm path, never silently allowed or silently blocked.
+
+This module carries NO benchmark data. It is exercised by synthetic fixtures in
+test_effect_taxonomy.py (the worked examples from the two design docs). Only such
+synthetic-fixture logic is content-safe to promote; the ledger built over real
+traces (build_effect_ledger.py) stays local and tainted.
+
+CONTENT-SAFETY: stdlib only; no receipts, ledgers, corpora, or models. The
+registry notes paraphrase public AgentDojo tool docstrings only. Promoted to the
+public package from the local research lane; the tainted ledger/calibration
+artifacts stay local and are NOT part of this module.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+# ----------------------------------------------------------------------------
+# Effect kinds, axes, observability tags (taxonomy Part A / B / C / F)
+# ----------------------------------------------------------------------------
+
+EFFECT_KINDS = (
+    "financial", "exfil", "information_access", "credential", "access_control",
+    "integrity", "destruction", "resource", "physical", "ambiguous",
+)
+
+# observability tags
+OBSERVED, CODE_DERIVED, SPEC_DERIVED, CONTEXT_REQUIRED = (
+    "OBSERVED", "CODE_DERIVED", "SPEC_DERIVED", "CONTEXT_REQUIRED",
+)
+
+# the kinds that are content WRITES to state (subject to the sink_visibility
+# ambiguity per taxonomy Part D / rubric pseudocode). Outbound SENDS are NOT
+# content-writes-to-state and are exempt from the unknown-visibility -> UNKNOWN
+# rule (rubric fix #2: recipient scope is an identity fact, not a severity fact).
+_CONTENT_WRITE_KINDS = {"integrity", "credential"}
+
+# kinds that count as effect ACTIONS (mirrors directive_floor.is_action). Reads
+# (information_access) are recorded in the ledger but are not action edges; the
+# calibration's attack/benign action sets use is_action edges only.
+ACTION_KINDS = {
+    "financial", "exfil", "credential", "access_control", "integrity",
+    "destruction", "resource", "physical", "ambiguous",
+}
+
+
+def is_action_kind(kind: str) -> bool:
+    return kind in ACTION_KINDS
+
+
+# ----------------------------------------------------------------------------
+# Extractor registry (taxonomy Part D) -- authored from tool docs ONLY.
+#
+# Each entry:
+#   kind:        primary effect_kind (or a callable rule(args) -> kind for the
+#                ambiguous-by-default functions)
+#   secondary:   optional secondary kind
+#   payloads:    {payload_field: arg_name}  (doc-supported mapping)
+#   sink_visibility: declared per content-write/exfil tool (Part D rule); None
+#                where the axis does not apply
+#   availability_impact: declared where the op is designed to lock/exhaust/destroy
+#                (taxonomy Part B scoping); default None -> "none"
+#   is_action:   override (defaults True for ACTION_KINDS)
+#   note:        the doc sentence supporting the mapping (registry-as-code trail)
+# ----------------------------------------------------------------------------
+
+
+def _create_file_kind(args):
+    # Two distinct create_file tools share the name. cloud_drive create_file uses
+    # `filename` (doc: "Create a new file in the cloud drive"); filesystem
+    # create_file uses `path` (doc: "create a new file" on the local Filesystem).
+    # Cloud-drive visibility is NOT intrinsic to the call (depends on drive
+    # sharing state the engine cannot see), so it is declared unknown -> routes
+    # to ambiguous (taxonomy Part D honest-expectation note). Filesystem writes
+    # are local/private -> integrity.
+    if "filename" in args and "path" not in args:
+        return "ambiguous"
+    return "integrity"
+
+
+REGISTRY = {
+    # ---- financial (banking + shopping) --------------------------------------
+    "send_money": {"kind": "financial", "payloads": {"amount": "amount", "recipient_ref": "recipient"},
+                   "note": "send_money(recipient, amount, subject, date): amount = transaction amount; recipient = IBAN"},
+    "schedule_transaction": {"kind": "financial", "payloads": {"amount": "amount", "recipient_ref": "recipient"},
+                             "note": "schedule_transaction(recipient, amount, ...)"},
+    "update_scheduled_transaction": {"kind": "financial", "payloads": {"amount": "amount", "recipient_ref": "recipient"},
+                                     "note": "update_scheduled_transaction(id, amount, recipient, ...)"},
+    "pay_money": {"kind": "financial", "payloads": {"amount": "amount", "recipient_ref": "recipient"},
+                  "note": "pay_money(recipient, amount, ...) shopping"},
+    "refund_order": {"kind": "financial", "payloads": {"resource_id": "order_id"},
+                     "note": "refund_order(order_id): commits a refund; no amount arg exposed -> amount NULL"},
+    "checkout_selected_cart": {"kind": "financial", "payloads": {},
+                               "note": "checkout_selected_cart(product_ids, discount_code): commits a purchase; no amount arg"},
+
+    # ---- exfil (outbound sends + durable public publication) -----------------
+    "send_email": {"kind": "exfil", "payloads": {"recipient_ref": "recipients", "content_ref": "body"},
+                   "sink_visibility": None,
+                   "note": "send_email(recipients, subject, body, ...): outbound send; recipient scope is an identity fact (no visibility bump for ordinary send)"},
+    "send_direct_message": {"kind": "exfil", "payloads": {"recipient_ref": "recipient", "content_ref": "body"},
+                            "sink_visibility": None,
+                            "note": "send_direct_message(recipient, body): outbound DM"},
+    "send_channel_message": {"kind": "exfil", "payloads": {"recipient_ref": "channel", "content_ref": "body"},
+                             "sink_visibility": "shared_internal",
+                             "note": "send_channel_message(channel, body): posts to a shared channel"},
+    "post_webpage": {"kind": "exfil", "payloads": {"content_ref": "content", "recipient_ref": "url"},
+                     "sink_visibility": "external_public", "durable_write": True,
+                     "note": "post_webpage(url, content): posts a webpage at a URL = durable write to external-public state"},
+    "share_file": {"kind": "exfil", "payloads": {"recipient_ref": "email", "content_ref": "file_id"},
+                   "sink_visibility": None,
+                   "note": "share_file(file_id, email, permission): shares a file OUT to an email recipient"},
+
+    # ---- credential (secret-material lifecycle) ------------------------------
+    # password rotation: whether it LOCKS the prior holder is CONTEXT_REQUIRED
+    # (taxonomy Part B explicit example) -> availability_impact unknown, never
+    # guessed deny. credential base 3 already prices secret handling.
+    "update_password": {"kind": "credential", "payloads": {"secret_ref": "password"}, "sink_visibility": "private",
+                        "availability_impact": "unknown",
+                        "note": "update_password(password): rotates the account secret; lockout of prior holder is CONTEXT_REQUIRED -> availability unknown"},
+    "update_shopping_account_password": {"kind": "credential", "payloads": {"secret_ref": "password"}, "sink_visibility": "private",
+                                         "availability_impact": "unknown",
+                                         "note": "update_shopping_account_password(password)"},
+    "update_github_account_password": {"kind": "credential", "payloads": {"secret_ref": "password"}, "sink_visibility": "private",
+                                       "availability_impact": "unknown",
+                                       "note": "update_github_account_password(password)"},
+
+    # ---- access_control (ADDITIVE permission-graph mutation) ------------------
+    "git_add_ssh_key": {"kind": "access_control", "secondary": "credential", "payloads": {"secret_ref": "ssh_key"},
+                        "note": "git_add_ssh_key(ssh_key): adds a key that grants standing access (taxonomy worked example: primary access_control)"},
+    "git_invite_collaborators": {"kind": "access_control", "payloads": {"recipient_ref": "collaborator_email", "resource_id": "repo_name"},
+                                 "note": "git_invite_collaborators(repo_name, collaborator_email): grants repo access"},
+    "git_transfer_repo_ownership": {"kind": "access_control", "payloads": {"recipient_ref": "new_owner_email", "resource_id": "repo_name"},
+                                    "note": "git_transfer_repo_ownership(repo_name, new_owner_username, new_owner_email): transfers ownership (additive grant to other)"},
+    "invite_user_to_slack": {"kind": "access_control", "payloads": {"recipient_ref": "user_email"},
+                             "note": "invite_user_to_slack(user, user_email): invites a user to the workspace"},
+    "add_user_to_channel": {"kind": "access_control", "payloads": {"recipient_ref": "user", "resource_id": "channel"},
+                            "note": "add_user_to_channel(user, channel): grants channel access"},
+    "add_calendar_event_participants": {"kind": "access_control", "payloads": {"recipient_ref": "participants", "resource_id": "event_id"},
+                                        "note": "add_calendar_event_participants(event_id, participants): grants event access to participants"},
+
+    # ---- destruction (delete/remove/revoke) ----------------------------------
+    # availability_impact=deny ONLY where the op destroys an ACCESS MECHANISM
+    # (key/right/account), per taxonomy Part B scoping. Content deletes
+    # (file/email/repo/event) are destruction base 3 with availability none;
+    # their reversibility is unknown -> unresolved_impact friction flag.
+    "delete_file": {"kind": "destruction", "payloads": {"resource_id": "file_id"},
+                    "note": "delete_file(file_id): removes a file (content delete; availability axis out of scope)"},
+    "delete_node": {"kind": "destruction", "payloads": {"resource_id": "path"},
+                    "note": "delete_node(path): deletes a filesystem node (content)"},
+    "delete_email": {"kind": "destruction", "payloads": {"resource_id": "email_id"},
+                     "note": "delete_email(email_id): deletes an email (content)"},
+    "git_delete_repo": {"kind": "destruction", "payloads": {"resource_id": "repo_name"},
+                        "note": "git_delete_repo(repo_name): deletes a repository (content/resource)"},
+    "git_delete_ssh_key": {"kind": "destruction", "secondary": "credential", "payloads": {"secret_ref": "ssh_key"},
+                           "availability_impact": "deny",
+                           "note": "git_delete_ssh_key(ssh_key): destroys an access mechanism (key); availability deny (Part B in-scope). Worked example: destruction primary, credential secondary"},
+    "remove_user_from_slack": {"kind": "destruction", "secondary": "access_control", "payloads": {"resource_id": "user"},
+                               "availability_impact": "deny",
+                               "note": "remove_user_from_slack(user): revokes a standing right; availability deny (Part B in-scope). destruction primary, access_control secondary"},
+    "cancel_calendar_event": {"kind": "destruction", "payloads": {"resource_id": "event_id"},
+                              "note": "cancel_calendar_event(event_id): cancels an event (content)"},
+    # R7-001 (registry-as-code review r7): removed git_delete_ssh_key_wo_verification.
+    # It has no definition in canonical v1/tools (only git_delete_ssh_key exists);
+    # it was an assumed-by-analogy entry to git_invite_collaborators_wo_verification
+    # with no doc sentence, and 0 occurrences in the ledger.
+
+    # ---- integrity (persistent NON-secret content to private/internal) -------
+    "create_file": {"kind": _create_file_kind, "payloads": {"content_ref": "content"}, "sink_visibility": "by_rule",
+                    "note": "create_file: cloud (filename arg) visibility unknown -> ambiguous; filesystem (path arg) private -> integrity"},
+    "append_to_file": {"kind": "ambiguous", "payloads": {"content_ref": "content", "resource_id": "file_id"}, "sink_visibility": "unknown",
+                       "note": "append_to_file(file_id, content): cloud-drive write; visibility not intrinsic to call -> unknown -> ambiguous"},
+    "create_dir": {"kind": "integrity", "payloads": {"resource_id": "path"}, "sink_visibility": "private",
+                   "note": "create_dir(path): local filesystem dir create (private)"},
+    "move_node": {"kind": "integrity", "payloads": {"resource_id": "source_path"}, "sink_visibility": "private",
+                  "note": "move_node(source_path, destination_path): local fs move"},
+    "copy_node": {"kind": "integrity", "payloads": {"resource_id": "source_path"}, "sink_visibility": "private",
+                  "note": "copy_node(source_path, destination_path): local fs copy"},
+    "update_user_info": {"kind": "integrity", "payloads": {}, "sink_visibility": "private",
+                         "note": "update_user_info(first_name, last_name, street, city): mutates own account fields (private)"},
+    "update_shopping_account_user_info": {"kind": "integrity", "payloads": {}, "sink_visibility": "private",
+                                          "note": "shopping account info update (private)"},
+    "create_calendar_event": {"kind": "integrity", "payloads": {"content_ref": "title", "recipient_ref": "participants"}, "sink_visibility": "private",
+                              "note": "create_calendar_event(title, ..., participants): creates a calendar entry"},
+    "reschedule_calendar_event": {"kind": "integrity", "payloads": {"resource_id": "event_id"}, "sink_visibility": "private",
+                                  "note": "reschedule_calendar_event(event_id, ...): mutates an event (private)"},
+    "cart_add_product": {"kind": "integrity", "payloads": {"resource_id": "product_id"}, "sink_visibility": "private",
+                         "note": "cart_add_product(product_id, quantity): mutates the cart (private state)"},
+    "cart_remove_product": {"kind": "integrity", "payloads": {"resource_id": "product_id"}, "sink_visibility": "private",
+                            "note": "cart_remove_product(product_id): mutates the cart"},
+    "clear_cart": {"kind": "integrity", "payloads": {}, "sink_visibility": "private", "note": "clear_cart(): empties the cart"},
+    "download_file_through_url": {"kind": "integrity", "payloads": {"resource_id": "save_dir"}, "sink_visibility": "private",
+                                 "note": "download_file_through_url(url, save_dir): writes a downloaded file locally"},
+    "download_file_through_id": {"kind": "integrity", "payloads": {"resource_id": "save_dir"}, "sink_visibility": "private",
+                                "note": "download_file_through_id(file_id, save_dir): writes a downloaded file locally"},
+    "git_create_repo": {"kind": "integrity", "payloads": {"resource_id": "repo_name"}, "sink_visibility": "private",
+                        "note": "git_create_repo(repo_name): creates a repo"},
+    "git_push": {"kind": "integrity", "payloads": {"resource_id": "local_path"}, "sink_visibility": "shared_internal",
+                 "note": "git_push(local_path, force): pushes content to the remote repo"},
+    "git_issue": {"kind": "integrity", "payloads": {"content_ref": "comment_body", "resource_id": "repo_name"}, "sink_visibility": "shared_internal",
+                  "note": "git_issue(repo_name, title, comment_body): files an issue"},
+    # R7-005 (review r7): git_clone reclassified resource -> integrity. Doc: "Clone a
+    # remote repository ... into a specific local directory" = a local-FS write, the
+    # SAME mechanical act download_file_through_* is typed integrity for. resource was
+    # an internal inconsistency.
+    "git_clone": {"kind": "integrity", "payloads": {"resource_id": "local_dir_path"}, "sink_visibility": "private",
+                  "note": "git_clone(repo_name, local_dir_path): writes the cloned repo to a local directory = local-private content write (integrity), consistent with download_file_through_*"},
+    # R7-002 (review r7): git_pull moved out of the read fallback. Doc: "Pull files from
+    # GitHub to the local filesystem ... synchronize the whole repo state" + overwrite_local
+    # param = a local-FS write, not a non-action read.
+    "git_pull": {"kind": "integrity", "payloads": {"resource_id": "local_path"}, "sink_visibility": "private",
+                 "note": "git_pull(local_path, repo_name, overwrite_local): writes/overwrites files on the local filesystem = local-private write"},
+
+    # ---- resource (consume/commit a resource/service) ------------------------
+    "reserve_hotel": {"kind": "resource", "payloads": {"resource_id": "hotel"}, "note": "reserve_hotel(hotel, start_day, end_day)"},
+    "reserve_restaurant": {"kind": "resource", "payloads": {"resource_id": "restaurant"}, "note": "reserve_restaurant(restaurant, start_time)"},
+    "reserve_car_rental": {"kind": "resource", "payloads": {"resource_id": "company"}, "note": "reserve_car_rental(company, start_time, end_time)"},
+    # git_star / git_unstar KEPT as resource (registry-as-code review r7, R7-006):
+    # a star is a minimal social-metadata toggle ("Star the repository"); base-1
+    # (lowest action tier) is an honest magnitude floor. Reclassifying to integrity
+    # (base 2) would OVERprice a star. The taxonomy lacks a social-metadata kind =
+    # a noted gap, not a defect. (git_clone reclassified to integrity, see below.)
+    "git_star": {"kind": "resource", "payloads": {"resource_id": "repo_name"}, "note": "git_star(repo_name): stars a repo (social-metadata toggle; base-1 floor)"},
+    "git_unstar": {"kind": "resource", "payloads": {"resource_id": "repo_name"}, "note": "git_unstar(repo_name): unstars a repo (social-metadata toggle; base-1 floor)"},
+}
+
+# read / lookup / auth functions -> information_access (is_action=False, base 1).
+# A catch-all read rule below also captures unmapped get_/search_/list_/read_/
+# view_/browse_ functions so trivial catalog lookups are not mis-typed as effects.
+_READ_PREFIXES = ("get_", "search_", "list_", "read_", "view_", "browse_", "check_", "find_")
+# R7-002 / R7-007 (review r7): git_pull moved to a REGISTRY integrity entry (local-FS
+# write, above). The three verify_* OTP functions were REMOVED from this read fallback:
+# each one, on a correct OTP, EXECUTES the queued action
+# (`func, args = verification_stack[otp]; func(*args)`) = a commit point, not a read.
+# Removed -> they fall through to ambiguous/UNOBSERVED -> friction confirm (action path).
+_READ_EXPLICIT = {
+    "login_shopping_account", "login_github_account", "login", "git_login",
+    "input_to_webpage", "click_the_link", "plot_figure", "standardize_url",
+    "get_current_day", "git_get_linked_ssh_keys", "git_accept_collaboration_invitation",
+    "git_accept_invitation", "save_attachment",
+}
+
+# git_get_linked_ssh_keys reads secret material; declare data_sensitivity=secret
+# (doc: returns the account's linked ssh keys).
+_READ_SECRET = {"git_get_linked_ssh_keys"}
+
+
+def _registry_hash():
+    """Stable hash over the registry's data content (kind names, payloads,
+    declared axes, notes). Callables are hashed by qualname so a logic change to
+    a rule (e.g. _create_file_kind) also moves the hash."""
+    items = {}
+    for fn, e in REGISTRY.items():
+        k = e["kind"]
+        items[fn] = {
+            "kind": getattr(k, "__qualname__", k),
+            "secondary": e.get("secondary"),
+            "payloads": e.get("payloads", {}),
+            "sink_visibility": e.get("sink_visibility"),
+            "availability_impact": e.get("availability_impact"),
+            "durable_write": e.get("durable_write", False),
+            "note": e.get("note", ""),
+        }
+    items["_READ_EXPLICIT"] = sorted(_READ_EXPLICIT)
+    items["_READ_PREFIXES"] = list(_READ_PREFIXES)
+    items["_READ_SECRET"] = sorted(_READ_SECRET)
+    blob = json.dumps(items, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
+# Hash-freeze: computed live, compared against the pin below. Update the pin
+# DELIBERATELY (a registry edit is a governed event), never silently.
+REGISTRY_LIVE_SHA256 = _registry_hash()
+# Re-pinned 2026-06-20 as a deliberate governed event after registry-as-code review
+# r7 (registry_review_r7.md): R7-001 remove phantom git_delete_ssh_key_wo_verification;
+# R7-002 git_pull read->integrity; R7-005 git_clone resource->integrity; R7-007 three
+# verify_* OTP commit points read->action. Prior pin: 562d686f9a09460c...e08e0e1.
+REGISTRY_FROZEN_SHA256 = "23915fe4eab9ea094ef578aacd9316f5086da585fbddfcddf061dfe3ebed508d"
+
+
+# ----------------------------------------------------------------------------
+# Extraction (taxonomy Part D/E -> LedgerEffectEvent)
+# ----------------------------------------------------------------------------
+
+_SECRET_HINT = re.compile(r"(password|secret|api[_-]?key|token|ssh|private[_-]?key|credential)", re.I)
+
+
+def _looks_like_secret(args: dict) -> bool:
+    """Doc/spec-derivable secret hint from arg NAMES only (never reads values into
+    any promoted artifact). Used to set secret_ref on send/write payloads whose
+    content carries secret material."""
+    for k in args or {}:
+        if _SECRET_HINT.search(str(k)):
+            return True
+    return False
+
+
+def extract(function: str, args: dict, position=None):
+    """Map an OBSERVED (function, args) call to a typed LedgerEffectEvent dict.
+
+    Returns a dict with effect_kind (may be 'ambiguous'), payloads, the three
+    mechanical axes, derivation tags, and coverage. Unmapped functions ->
+    'ambiguous' with coverage='UNOBSERVED_UNTIL_EXTRACTOR_DEFINED'.
+    """
+    args = args if isinstance(args, dict) else {}
+    ev = {
+        "function": function, "position": position,
+        "effect_kind": None, "effect_kind_secondary": None,
+        "payloads": {}, "availability_impact": "none", "sink_visibility": "n/a",
+        "reversibility": "unknown", "data_sensitivity": "unknown",
+        "is_action": True, "coverage": "covered", "derivation": {},
+    }
+
+    entry = REGISTRY.get(function)
+    if entry is None:
+        # read / lookup / auth fallback -> information_access (non-action)
+        if function in _READ_EXPLICIT or (function and function.startswith(_READ_PREFIXES)):
+            ev.update(effect_kind="information_access", is_action=False,
+                      data_sensitivity=("secret" if function in _READ_SECRET else "unknown"),
+                      coverage="covered_read_fallback")
+            ev["derivation"] = {"effect_kind": SPEC_DERIVED, "data_sensitivity": CONTEXT_REQUIRED}
+            return ev
+        # genuinely unmapped (incl. model-hallucinated functions)
+        ev.update(effect_kind="ambiguous", coverage="UNOBSERVED_UNTIL_EXTRACTOR_DEFINED")
+        ev["derivation"] = {"effect_kind": SPEC_DERIVED}
+        return ev
+
+    kind = entry["kind"]
+    if callable(kind):
+        kind = kind(args)
+    ev["effect_kind"] = kind
+    ev["effect_kind_secondary"] = entry.get("secondary")
+    ev["is_action"] = entry.get("is_action", is_action_kind(kind))
+
+    # payloads (doc-supported mapping)
+    for field, arg_name in entry.get("payloads", {}).items():
+        if arg_name in args and args[arg_name] not in (None, ""):
+            ev["payloads"][field] = args[arg_name]
+            ev["derivation"][field] = SPEC_DERIVED
+
+    # secret_ref on a SEND/WRITE whose content carries secret material (arg-name
+    # hint). credential entries already declare secret_ref via payloads.
+    if "secret_ref" not in ev["payloads"] and kind in ("exfil", "integrity"):
+        if _looks_like_secret(args):
+            ev["payloads"]["secret_ref"] = "<secret-named-arg>"
+            ev["derivation"]["secret_ref"] = SPEC_DERIVED
+
+    # sink_visibility
+    sv = entry.get("sink_visibility", "n/a")
+    if sv == "by_rule":
+        # create_file rule: cloud (filename) unknown, filesystem (path) private
+        sv = "unknown" if ("filename" in args and "path" not in args) else "private"
+    if sv is None:
+        sv = "n/a"  # outbound send: visibility axis does not apply
+    ev["sink_visibility"] = sv
+    if sv in ("private", "shared_internal", "external_public"):
+        ev["derivation"]["sink_visibility"] = SPEC_DERIVED
+    elif sv == "unknown":
+        ev["derivation"]["sink_visibility"] = CONTEXT_REQUIRED
+
+    # availability_impact (mechanical; only declared lock/exhaust/destroy ops)
+    ai = entry.get("availability_impact", "none")
+    ev["availability_impact"] = ai
+    ev["derivation"]["availability_impact"] = SPEC_DERIVED if ai != "none" else CODE_DERIVED
+
+    # durable write flag (post_webpage) -> mark on event for g
+    ev["durable_write"] = entry.get("durable_write", False)
+
+    # content-write with unknown visibility -> route to ambiguous (taxonomy Part D)
+    if kind in _CONTENT_WRITE_KINDS and sv == "unknown":
+        ev["effect_kind"] = "ambiguous"
+        ev["coverage"] = "ambiguous_unknown_visibility"
+
+    return ev
+
+
+# ----------------------------------------------------------------------------
+# g = intrinsic_effect_severity (rubric Part 1) -- MECHANICAL FACTS ONLY
+# ----------------------------------------------------------------------------
+
+BASE_LEVEL = {
+    "resource": 1, "information_access": 1, "integrity": 2, "financial": 2,
+    "exfil": 3, "credential": 3, "access_control": 3, "destruction": 3,
+    "physical": 4,
+}
+
+AMOUNT_TIER_HI = 1000.0   # v0-OPERATIONAL (sensitivity-analysed pre-run)
+AMOUNT_TIER_LO = 100.0    # v0-OPERATIONAL
+
+UNKNOWN_SEVERITY = "unknown"
+
+
+def _to_amount(v):
+    if v is None:
+        return None
+    try:
+        return float(str(v).replace(",", "").lstrip("$").strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def amount_tier(amount):
+    """financial amount modifier. Returns (delta, unknown_magnitude_flag)."""
+    a = _to_amount(amount)
+    if a is None:
+        return 0, True
+    if a >= AMOUNT_TIER_HI:
+        return 2, False
+    if a >= AMOUNT_TIER_LO:
+        return 1, False
+    return 0, False
+
+
+def is_content_write(event) -> bool:
+    return event.get("effect_kind") in _CONTENT_WRITE_KINDS
+
+
+def is_durable_write(event) -> bool:
+    return bool(event.get("durable_write"))
+
+
+def g(event, hi=None, lo=None):
+    """intrinsic_effect_severity = g(mechanical facts). Returns
+    (severity, flags). severity is 1-4 or UNKNOWN_SEVERITY. flags is a set.
+
+    hi/lo override the amount thresholds for the sensitivity analysis ONLY; the
+    pinned run uses the v0-operational defaults.
+    """
+    global AMOUNT_TIER_HI, AMOUNT_TIER_LO
+    if hi is not None or lo is not None:
+        save_hi, save_lo = AMOUNT_TIER_HI, AMOUNT_TIER_LO
+        AMOUNT_TIER_HI = hi if hi is not None else save_hi
+        AMOUNT_TIER_LO = lo if lo is not None else save_lo
+        try:
+            return g(event)
+        finally:
+            AMOUNT_TIER_HI, AMOUNT_TIER_LO = save_hi, save_lo
+
+    kind = event.get("effect_kind")
+    flags = set()
+
+    # ambiguous / unknown-visibility content write -> not scored, route to friction
+    if kind == "ambiguous":
+        return UNKNOWN_SEVERITY, {"route_friction"}
+    if is_content_write(event) and event.get("sink_visibility") == "unknown":
+        return UNKNOWN_SEVERITY, {"route_friction"}
+
+    s = BASE_LEVEL[kind]
+
+    if kind == "financial":
+        d, unk = amount_tier(event.get("payloads", {}).get("amount"))
+        s += d
+        if unk:
+            flags.add("unknown_magnitude")
+
+    # secret payload +1: a secret TRAVELING via an exfil/integrity effect. NOT
+    # credential -- credential base 3 already prices secret handling (the rubric
+    # update_password worked example = 3 confirms credential takes no secret +1).
+    if event.get("payloads", {}).get("secret_ref") is not None and kind in ("exfil", "integrity"):
+        s += 1
+
+    if event.get("sink_visibility") == "external_public" and is_durable_write(event):
+        s += 1
+
+    if event.get("reversibility") == "irreversible":
+        s += 1
+
+    if event.get("availability_impact") == "deny":
+        s += 1
+
+    if kind == "information_access" and event.get("data_sensitivity") in ("secret", "PII"):
+        s += 1
+
+    # unresolved-impact friction flag for high-base kinds (rubric 1.5)
+    if BASE_LEVEL[kind] >= 3 and (event.get("reversibility") == "unknown"
+                                  or event.get("availability_impact") == "unknown"):
+        flags.add("unresolved_impact")
+
+    return max(1, min(4, s)), flags
+
+
+# ----------------------------------------------------------------------------
+# Identity-free FRICTION gate (taxonomy Part I) -- keyed on effect_kind/severity.
+# NOT a harmfulness gate. Handles ambiguous as first-class (confirm/dry-run).
+# ----------------------------------------------------------------------------
+
+def friction_gate(event, threshold=3):
+    """Identity-free coarse friction decision. Returns one of:
+      'confirm'  -- ambiguous / unresolved: route to confirm/dry-run path
+      'friction' -- typed effect at/above the severity threshold
+      'allow'    -- below threshold (low-severity typed effect or read)
+
+    This is the buildable-now control: it has NO access to authorization /
+    identity, so it WILL fire on benign high-severity actions. That benign-break
+    is the quantity the calibration measures.
+    """
+    sev, flags = g(event)
+    if sev == UNKNOWN_SEVERITY:
+        return "confirm", sev, flags
+    if "unresolved_impact" in flags:
+        return "confirm", sev, flags
+    if sev >= threshold:
+        return "friction", sev, flags
+    return "allow", sev, flags
+
+
+def freeze_registry():
+    """Print the live registry hash for pinning REGISTRY_FROZEN_SHA256."""
+    print(REGISTRY_LIVE_SHA256)
+
+
+if __name__ == "__main__":
+    freeze_registry()

--- a/parapet-data/tests/effects/test_effect_taxonomy.py
+++ b/parapet-data/tests/effects/test_effect_taxonomy.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Synthetic-fixture tests for the Phase-1 effect-event taxonomy abstraction.
+
+Fixtures are the worked examples from the two converged design docs:
+  * effect_event_taxonomy.md v2.2 (kind map + precedence + ambiguous routing)
+  * effect_severity_rubric.md v1.1 (g worked examples per severity bucket)
+
+NO benchmark data here. Hand-authored synthetic calls only -> content-safe to
+promote behind the executable content-safety guard. Stdlib only; runs as a
+script (exit 0 = pass) and is pytest-discoverable.
+"""
+import sys
+
+from parapet_data.effects import effect_taxonomy as t
+
+
+# --- registry hash freeze ----------------------------------------------------
+
+def test_registry_is_frozen():
+    assert t.REGISTRY_LIVE_SHA256 == t.REGISTRY_FROZEN_SHA256, (
+        "registry changed without re-pinning REGISTRY_FROZEN_SHA256 "
+        f"(live={t.REGISTRY_LIVE_SHA256})")
+
+
+# --- g severity arithmetic (rubric Part 1 worked examples) -------------------
+# These pass explicit FACT dicts so they test g's arithmetic independent of the
+# registry (the registry decides which facts a real tool yields).
+
+def _ev(kind, **kw):
+    ev = {"effect_kind": kind, "payloads": kw.pop("payloads", {}),
+          "availability_impact": kw.pop("availability_impact", "none"),
+          "sink_visibility": kw.pop("sink_visibility", "n/a"),
+          "reversibility": kw.pop("reversibility", "reversible"),
+          "data_sensitivity": kw.pop("data_sensitivity", "unknown"),
+          "durable_write": kw.pop("durable_write", False)}
+    ev.update(kw)
+    return ev
+
+
+def test_g_bucket_1_low():
+    assert t.g(_ev("resource"))[0] == 1
+    assert t.g(_ev("information_access"))[0] == 1
+
+
+def test_g_bucket_2_moderate():
+    assert t.g(_ev("integrity", sink_visibility="private"))[0] == 2
+    assert t.g(_ev("financial", payloads={"amount": 50}))[0] == 2
+
+
+def test_g_bucket_3_high():
+    # ordinary send: exfil base 3, NO visibility bump
+    assert t.g(_ev("exfil"))[0] == 3
+    # credential rotation, reversible
+    assert t.g(_ev("credential"))[0] == 3
+    # access_control invite
+    assert t.g(_ev("access_control"))[0] == 3
+
+
+def test_g_bucket_4_critical():
+    # send_money 50000 -> 2 + 2
+    assert t.g(_ev("financial", payloads={"amount": 50000}))[0] == 4
+    # post_webpage publishing a secret to a public page: 3 + secret 1 + durable-public 1 -> clamp 4
+    assert t.g(_ev("exfil", payloads={"secret_ref": "x"}, sink_visibility="external_public",
+                   durable_write=True))[0] == 4
+    # physical
+    assert t.g(_ev("physical"))[0] == 4
+    # irreversible delete: destruction 3 + irreversible 1 -> 4
+    assert t.g(_ev("destruction", reversibility="irreversible", availability_impact="deny"))[0] == 4
+
+
+def test_g_amount_tiers():
+    assert t.g(_ev("financial", payloads={"amount": 99}))[0] == 2     # +0
+    assert t.g(_ev("financial", payloads={"amount": 100}))[0] == 3    # +1
+    assert t.g(_ev("financial", payloads={"amount": 999}))[0] == 3    # +1
+    assert t.g(_ev("financial", payloads={"amount": 1000}))[0] == 4   # +2
+
+
+def test_g_unknown_magnitude_flag():
+    sev, flags = t.g(_ev("financial", payloads={}))
+    assert sev == 2 and "unknown_magnitude" in flags
+
+
+def test_g_information_access_sensitive_bump():
+    assert t.g(_ev("information_access", data_sensitivity="secret"))[0] == 2
+    assert t.g(_ev("information_access", data_sensitivity="PII"))[0] == 2
+
+
+def test_g_unresolved_impact_flag_high_base():
+    # destruction (base 3) with unknown reversibility -> unresolved_impact friction flag
+    sev, flags = t.g(_ev("destruction", reversibility="unknown", availability_impact="deny"))
+    assert "unresolved_impact" in flags
+
+
+def test_g_ambiguous_returns_unknown():
+    sev, flags = t.g(_ev("ambiguous"))
+    assert sev == t.UNKNOWN_SEVERITY and "route_friction" in flags
+
+
+def test_g_content_write_unknown_visibility_unknown_severity():
+    sev, _ = t.g(_ev("integrity", sink_visibility="unknown"))
+    assert sev == t.UNKNOWN_SEVERITY
+
+
+def test_g_never_reads_authorization():
+    # identical facts, opposite authorization -> identical severity (g is blind)
+    a = _ev("financial", payloads={"amount": 500}); a["authorization"] = "not_in_intent"
+    b = _ev("financial", payloads={"amount": 500}); b["authorization"] = "within_standing_intent"
+    assert t.g(a)[0] == t.g(b)[0]
+
+
+# --- extractor registry (taxonomy Part A/D worked examples) ------------------
+
+def test_extract_send_money_financial():
+    ev = t.extract("send_money", {"recipient": "DE123", "amount": 1500, "subject": "x", "date": "2024"})
+    assert ev["effect_kind"] == "financial"
+    assert ev["payloads"]["amount"] == 1500
+    assert ev["payloads"]["recipient_ref"] == "DE123"
+    assert t.g(ev)[0] == 4
+
+
+def test_extract_send_email_exfil_no_visibility_bump():
+    ev = t.extract("send_email", {"recipients": ["a@b.com"], "subject": "s", "body": "hi"})
+    assert ev["effect_kind"] == "exfil"
+    assert t.g(ev)[0] == 3   # ordinary send, no bump
+
+
+def test_extract_post_webpage_durable_public():
+    ev = t.extract("post_webpage", {"url": "http://x", "content": "the api_key is leaked"})
+    assert ev["effect_kind"] == "exfil"
+    assert ev["sink_visibility"] == "external_public"
+    assert ev["durable_write"] is True
+    # content arg has no secret-named KEY here, so secret_ref not set by name-hint;
+    # base 3 + durable-public 1 = 4
+    assert t.g(ev)[0] == 4
+
+
+def test_extract_git_delete_ssh_key_destruction_credential():
+    ev = t.extract("git_delete_ssh_key", {"ssh_key": "ssh-rsa AAAA"})
+    assert ev["effect_kind"] == "destruction"
+    assert ev["effect_kind_secondary"] == "credential"
+    assert ev["availability_impact"] == "deny"
+    # reversibility unknown -> no irreversible bump, but unresolved_impact flag; base 3 + deny 1 = 4
+    sev, flags = t.g(ev)
+    assert sev == 4 and "unresolved_impact" in flags
+
+
+def test_extract_git_add_ssh_key_access_control():
+    ev = t.extract("git_add_ssh_key", {"ssh_key": "ssh-rsa AAAA"})
+    assert ev["effect_kind"] == "access_control"
+    assert ev["effect_kind_secondary"] == "credential"
+    assert t.g(ev)[0] == 3
+
+
+def test_extract_update_password_credential():
+    ev = t.extract("update_password", {"password": "hunter2"})
+    assert ev["effect_kind"] == "credential"
+    assert ev["payloads"].get("secret_ref") == "hunter2"
+    # lockout is CONTEXT_REQUIRED -> availability unknown, not deny
+    assert ev["availability_impact"] == "unknown"
+    # rubric worked example: credential base 3, reversible, NO secret +1 -> 3
+    sev, flags = t.g(ev)
+    assert sev == 3 and "unresolved_impact" in flags
+
+
+def test_extract_cloud_create_file_ambiguous():
+    # cloud-drive create_file: filename arg, no path -> visibility unknown -> ambiguous
+    ev = t.extract("create_file", {"filename": "notes.txt", "content": "hello"})
+    assert ev["effect_kind"] == "ambiguous"
+    assert t.g(ev)[0] == t.UNKNOWN_SEVERITY
+
+
+def test_extract_fs_create_file_integrity():
+    # filesystem create_file: path arg -> private -> integrity
+    ev = t.extract("create_file", {"path": "/tmp/x", "content": "hello"})
+    assert ev["effect_kind"] == "integrity"
+    assert ev["sink_visibility"] == "private"
+    assert t.g(ev)[0] == 2
+
+
+def test_extract_append_to_file_ambiguous():
+    ev = t.extract("append_to_file", {"file_id": "1", "content": "more"})
+    assert ev["effect_kind"] == "ambiguous"
+
+
+def test_extract_read_fallback_information_access():
+    ev = t.extract("get_received_emails", {})
+    assert ev["effect_kind"] == "information_access"
+    assert ev["is_action"] is False
+
+
+def test_extract_unmapped_function_ambiguous():
+    ev = t.extract("totally_made_up_tool", {"x": 1})
+    assert ev["effect_kind"] == "ambiguous"
+    assert ev["coverage"] == "UNOBSERVED_UNTIL_EXTRACTOR_DEFINED"
+
+
+def test_extract_access_control_invite():
+    ev = t.extract("git_invite_collaborators", {"repo_name": "r", "collaborator_email": "a@b.com"})
+    assert ev["effect_kind"] == "access_control"
+    assert ev["payloads"]["recipient_ref"] == "a@b.com"
+    assert t.g(ev)[0] == 3
+
+
+# --- registry-as-code review r7 corrections (worked examples) ----------------
+
+def test_extract_git_pull_is_local_write_not_read():
+    # R7-002: git_pull writes to the local filesystem -> integrity action, NOT a read.
+    ev = t.extract("git_pull", {"local_path": "/repo", "repo_name": "r", "overwrite_local": True})
+    assert ev["effect_kind"] == "integrity"
+    assert ev["is_action"] is True
+    assert ev["sink_visibility"] == "private"
+    assert t.g(ev)[0] == 2
+
+
+def test_extract_git_clone_integrity_not_resource():
+    # R7-005: git_clone writes the cloned repo locally = integrity (was resource).
+    ev = t.extract("git_clone", {"repo_name": "r", "local_dir_path": "/downloads"})
+    assert ev["effect_kind"] == "integrity"
+    assert t.g(ev)[0] == 2
+
+
+def test_extract_git_star_kept_resource():
+    # R7-006 arbitration: a star is a minimal social-metadata toggle, base-1 floor.
+    ev = t.extract("git_star", {"repo_name": "r"})
+    assert ev["effect_kind"] == "resource"
+    assert t.g(ev)[0] == 1
+    assert t.friction_gate(ev)[0] == "allow"
+
+
+def test_extract_verify_otp_is_action_confirm():
+    # R7-007: verify_* OTP functions execute the queued action -> action path, confirm.
+    for fn in ("verify_transaction", "verify_github_account", "verify_shopping_account"):
+        ev = t.extract(fn, {"otp": "123456"})
+        assert ev["is_action"] is True
+        assert ev["effect_kind"] == "ambiguous"
+        assert t.friction_gate(ev)[0] == "confirm"
+
+
+# --- friction gate (taxonomy Part I) ----------------------------------------
+
+def test_friction_gate_ambiguous_is_confirm():
+    ev = t.extract("create_file", {"filename": "x", "content": "y"})
+    assert t.friction_gate(ev)[0] == "confirm"
+
+
+def test_friction_gate_high_severity_friction():
+    ev = t.extract("send_money", {"recipient": "x", "amount": 5000})
+    assert t.friction_gate(ev)[0] == "friction"
+
+
+def test_friction_gate_low_severity_allow():
+    ev = t.extract("reserve_hotel", {"hotel": "h", "start_day": "1", "end_day": "2"})
+    assert t.friction_gate(ev)[0] == "allow"
+
+
+def test_friction_gate_unresolved_impact_confirm():
+    ev = t.extract("git_delete_repo", {"repo_name": "r"})
+    # destruction base 3, deny, reversibility unknown -> unresolved_impact -> confirm
+    assert t.friction_gate(ev)[0] == "confirm"
+
+
+# --- runner ------------------------------------------------------------------
+
+def _run():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run() else 0)

--- a/parapet-data/tests/effects/test_effect_taxonomy.py
+++ b/parapet-data/tests/effects/test_effect_taxonomy.py
@@ -6,8 +6,11 @@ Fixtures are the worked examples from the two converged design docs:
   * effect_severity_rubric.md v1.1 (g worked examples per severity bucket)
 
 NO benchmark data here. Hand-authored synthetic calls only -> content-safe to
-promote behind the executable content-safety guard. Stdlib only; runs as a
-script (exit 0 = pass) and is pytest-discoverable.
+promote behind the executable content-safety guard. Stdlib only; pytest-
+discoverable, and runs as a script (exit 0 = pass) when parapet_data is
+importable, e.g. from parapet-data/:
+    PYTHONPATH=. python3 tests/effects/test_effect_taxonomy.py
+(or with parapet-data installed editable).
 """
 import sys
 


### PR DESCRIPTION
New content-safe subpackage parapet_data/effects: kind map, doc-sourced extractor registry (hash-frozen), intrinsic-severity g (mechanical facts only, never reads authorization), and the identity-free friction gate. Exercised by 32 synthetic-fixture tests under tests/effects (worked examples from the converged design docs); stdlib only, no data.

Registry authored from public AgentDojo tool docstrings and frozen at REGISTRY_FROZEN_SHA256 (registry-as-code review r7). Tainted ledger and calibration artifacts stay local and are not part of this module.