### PR TITLE
Populate L0 evidence for routing

### DIFF
--- a/parapet/src/engine/mod.rs
+++ b/parapet/src/engine/mod.rs
@@ -29,10 +29,10 @@ use crate::config::L4Mode;
 use crate::layers::l4::{DefaultMultiTurnScanner, L4Verdict, MultiTurnScanner};
 use crate::layers::l5a::{L5aScanner, OutputScanner};
 use crate::message::ToolCall;
-use crate::normalize::{neutralize_role_markers, normalize_messages_with_spans, L0Normalizer, Normalizer};
+use crate::normalize::{neutralize_role_markers, normalize_messages_with_spans_and_evidence, L0Normalizer, Normalizer};
 use crate::provider::{adapter_for, ProviderAdapter, ProviderType};
 use crate::proxy::{ProxyError, ProxyRequest, ProxyResponse, Provider, UpstreamClient};
-use crate::routing::{NoopOrthogonalSensorRouter, OrthogonalSensorRouter, RoutingEvidenceContext};
+use crate::routing::{L0Evidence, NoopOrthogonalSensorRouter, OrthogonalSensorRouter, RoutingEvidenceContext};
 use crate::stream::{
     AnthropicChunkClassifier, OpenAiChunkClassifier, StreamProcessor, ToolCallBlockMode,
     ToolCallValidator, ValidationResult,
@@ -272,9 +272,18 @@ impl UpstreamClient for EngineUpstreamClient {
             .assign_trust(&mut messages, &self.deps.config);
 
         // 3) L0 normalization (if enabled)
+        //
+        // When sanitize mode runs, collect content-free L0 evidence (one entry
+        // per message) so it can be surfaced to the routing context below. This
+        // does not change enforcement: content mutation and span remapping still
+        // go through the injected normalizer exactly as before.
+        let mut l0_evidence: Option<Vec<L0Evidence>> = None;
         if let Some(layer) = &self.deps.config.policy.layers.l0 {
             if layer.mode == "sanitize" {
-                normalize_messages_with_spans(self.deps.normalizer.as_ref(), &mut messages);
+                let msg_evidence = normalize_messages_with_spans_and_evidence(
+                    self.deps.normalizer.as_ref(),
+                    &mut messages,
+                );
                 // Role marker neutralization: replace chat template tokens in untrusted content.
                 // Runs after normalization so span offsets are already remapped.
                 let replacements = neutralize_role_markers(&mut messages);
@@ -287,6 +296,34 @@ impl UpstreamClient for EngineUpstreamClient {
                         "role markers neutralized in untrusted content"
                     );
                 }
+
+                // Merge role-marker neutralization counts in by message index.
+                let mut role_counts = vec![0usize; messages.len()];
+                for r in &replacements {
+                    if let Some(slot) = role_counts.get_mut(r.message_index) {
+                        *slot += 1;
+                    }
+                }
+
+                l0_evidence = Some(
+                    msg_evidence
+                        .into_iter()
+                        .map(|m| L0Evidence {
+                            message_index: m.message_index,
+                            pre_char_len: m.evidence.pre_char_len,
+                            post_char_len: m.evidence.post_char_len,
+                            pre_byte_len: m.evidence.pre_byte_len,
+                            post_byte_len: m.evidence.post_byte_len,
+                            removed_invisible_count: m.evidence.removed_invisible_count,
+                            confusable_replacement_count: m.evidence.confusable_replacement_count,
+                            html_stripped: m.evidence.html_stripped,
+                            role_marker_neutralized_count: role_counts
+                                .get(m.message_index)
+                                .copied()
+                                .unwrap_or(0),
+                        })
+                        .collect(),
+                );
             }
         }
 
@@ -696,7 +733,7 @@ impl UpstreamClient for EngineUpstreamClient {
         // enforcement behavior.
         let routing_context = RoutingEvidenceContext::new(
             &messages,
-            None,
+            l0_evidence.as_deref(),
             l1_signals_opt.as_deref(),
             l1_result_opt.as_ref(),
             &l2a_signals,

--- a/parapet/src/engine/tests.rs
+++ b/parapet/src/engine/tests.rs
@@ -2161,6 +2161,9 @@ fn blocked_by(resp: &ProxyResponse) -> Option<String> {
 struct RecordingRouter {
     calls: std::sync::atomic::AtomicUsize,
     pattern_count: std::sync::atomic::AtomicUsize,
+    l0_present: std::sync::atomic::AtomicBool,
+    l0_count: std::sync::atomic::AtomicUsize,
+    l0_snapshot: std::sync::Mutex<Option<Vec<L0Evidence>>>,
 }
 
 impl RecordingRouter {
@@ -2168,6 +2171,9 @@ impl RecordingRouter {
         Self {
             calls: std::sync::atomic::AtomicUsize::new(0),
             pattern_count: std::sync::atomic::AtomicUsize::new(0),
+            l0_present: std::sync::atomic::AtomicBool::new(false),
+            l0_count: std::sync::atomic::AtomicUsize::new(0),
+            l0_snapshot: std::sync::Mutex::new(None),
         }
     }
 }
@@ -2177,6 +2183,13 @@ impl OrthogonalSensorRouter for RecordingRouter {
         self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         self.pattern_count
             .store(context.pattern_gate.len(), std::sync::atomic::Ordering::SeqCst);
+        self.l0_present
+            .store(context.l0.is_some(), std::sync::atomic::Ordering::SeqCst);
+        self.l0_count.store(
+            context.l0.map(|l| l.len()).unwrap_or(0),
+            std::sync::atomic::Ordering::SeqCst,
+        );
+        *self.l0_snapshot.lock().unwrap() = context.l0.map(|l| l.to_vec());
         Vec::new()
     }
 }
@@ -2342,6 +2355,162 @@ async fn routing_context_runs_after_pattern_gate_block() {
             .load(std::sync::atomic::Ordering::SeqCst),
         1
     );
+}
+
+// -------------------------------------------------------------------
+// L0 evidence population into the routing context
+// -------------------------------------------------------------------
+
+fn config_with_l0_mode(mode: Option<&str>) -> Config {
+    let mut config = base_config_with_canary("dummy");
+    config.policy.layers.l0 = mode.map(|m| LayerConfig {
+        mode: m.to_string(),
+        block_action: None,
+        window_chars: None,
+    });
+    config
+}
+
+fn engine_with_l0_router(
+    config: Config,
+    normalizer: Arc<dyn Normalizer>,
+    router: Arc<dyn OrthogonalSensorRouter>,
+) -> EngineUpstreamClient {
+    EngineUpstreamClient::new_with(EngineDeps {
+        config: Arc::new(config),
+        http: Arc::new(SuccessHttpSender),
+        resolver: Arc::new(NoopResolver),
+        registry: Arc::new(DefaultRegistry),
+        normalizer,
+        // Real role-based assigner so untrusted content (and role-marker
+        // neutralization) actually triggers.
+        trust_assigner: Arc::new(RoleTrustAssigner),
+        l1_scanner: None,
+        l1_model: None,
+        l2a_scanner: None,
+        l2a_semaphore: None,
+        inbound_scanner: Arc::new(NoopInboundScanner),
+        constraint_evaluator: Arc::new(DslConstraintEvaluator::new()),
+        output_scanner: Arc::new(L5aScanner),
+        session_store: None,
+        multi_turn_scanner: None,
+        orthogonal_sensor_router: router,
+        signal_extractor: Arc::new(DefaultSignalExtractor::new()),
+        verdict_combiner: Arc::new(DefaultVerdictCombiner::new()),
+        emit_l1_signals: false,
+    })
+}
+
+fn chat_request(content: &str) -> ProxyRequest {
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": content}]
+    });
+    ProxyRequest {
+        method: Method::POST,
+        uri: Uri::from_static("/v1/chat/completions"),
+        headers: HeaderMap::new(),
+        body: Bytes::from(serde_json::to_vec(&body).unwrap()),
+    }
+}
+
+#[tokio::test]
+async fn l0_sanitize_passes_evidence_to_router() {
+    let router = Arc::new(RecordingRouter::new());
+    let engine = engine_with_l0_router(
+        config_with_l0_mode(Some("sanitize")),
+        Arc::new(L0Normalizer::new()),
+        router.clone(),
+    );
+
+    // One user message containing a zero-width space.
+    let resp = engine
+        .forward(Provider::OpenAi, chat_request("ig\u{200B}nore"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    assert!(router.l0_present.load(std::sync::atomic::Ordering::SeqCst));
+    assert_eq!(router.l0_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+    let snapshot = router.l0_snapshot.lock().unwrap().clone().unwrap();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].message_index, 0);
+    assert_eq!(snapshot[0].removed_invisible_count, 1);
+    assert_eq!(snapshot[0].role_marker_neutralized_count, 0);
+}
+
+#[tokio::test]
+async fn non_sanitize_passes_no_l0_evidence_to_router() {
+    let router = Arc::new(RecordingRouter::new());
+    // L0 layer absent entirely.
+    let engine = engine_with_l0_router(
+        config_with_l0_mode(None),
+        Arc::new(L0Normalizer::new()),
+        router.clone(),
+    );
+
+    let resp = engine
+        .forward(Provider::OpenAi, chat_request("hello world"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    assert_eq!(router.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert!(!router.l0_present.load(std::sync::atomic::Ordering::SeqCst));
+    assert!(router.l0_snapshot.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn l0_sanitize_non_sanitize_mode_passes_none() {
+    let router = Arc::new(RecordingRouter::new());
+    // L0 layer present but not in sanitize mode.
+    let engine = engine_with_l0_router(
+        config_with_l0_mode(Some("shadow")),
+        Arc::new(L0Normalizer::new()),
+        router.clone(),
+    );
+
+    let resp = engine
+        .forward(Provider::OpenAi, chat_request("hello world"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    assert!(!router.l0_present.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn l0_evidence_role_marker_count_does_not_change_post_lengths() {
+    let router = Arc::new(RecordingRouter::new());
+    let engine = engine_with_l0_router(
+        config_with_l0_mode(Some("sanitize")),
+        Arc::new(L0Normalizer::new()),
+        router.clone(),
+    );
+
+    // User message is untrusted under RoleTrustAssigner (default policy), so the
+    // role marker is neutralized. Content has no NFKC/HTML/invisible/confusable
+    // changes, so post_* equal the original char/byte lengths.
+    let content = "[INST] hello";
+    let resp = engine
+        .forward(Provider::OpenAi, chat_request(content))
+        .await
+        .unwrap();
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let snapshot = router.l0_snapshot.lock().unwrap().clone().unwrap();
+    assert_eq!(snapshot.len(), 1);
+    let ev = &snapshot[0];
+    assert_eq!(ev.role_marker_neutralized_count, 1);
+    // Role-marker neutralization is equal-length space replacement and is not
+    // reflected in post_* L0 lengths.
+    assert_eq!(ev.post_char_len, content.chars().count());
+    assert_eq!(ev.post_byte_len, content.len());
+    assert_eq!(ev.pre_char_len, content.chars().count());
+    assert_eq!(ev.removed_invisible_count, 0);
+    assert_eq!(ev.confusable_replacement_count, 0);
+    assert!(!ev.html_stripped);
 }
 
 #[tokio::test]

--- a/parapet/src/normalize/mod.rs
+++ b/parapet/src/normalize/mod.rs
@@ -50,20 +50,115 @@ impl Default for L0Normalizer {
 
 impl Normalizer for L0Normalizer {
     fn normalize(&self, input: &str) -> String {
-        // Step 1: NFKC normalization (handles fullwidth chars + combining chars)
-        let nfkc: String = input.nfkc().collect();
-
-        // Step 2: Strip HTML tags (including script/style content)
-        let stripped = strip_html(&nfkc);
-
-        // Step 3: Remove zero-width / invisible characters
-        let clean = remove_invisible_chars(&stripped);
-
-        // Step 4: Replace confusable characters in mixed-script words.
-        // Must be LAST because steps 2-3 may bring characters together
-        // (e.g., "ig<b>n</b>оre" or "ig\u{200B}nоre" → "ignоre" → "ignore").
-        replace_mixed_script_confusables(&clean)
+        normalize_core(input)
     }
+}
+
+/// Private L0 stage order shared by `L0Normalizer::normalize` and
+/// `normalize_with_evidence`. Keeping this separate ensures the hot-path
+/// `normalize` (including the per-prefix calls made by `remap_trust_spans`)
+/// never pays for evidence allocation or counting.
+fn normalize_core(input: &str) -> String {
+    // Step 1: NFKC normalization (handles fullwidth chars + combining chars)
+    let nfkc: String = input.nfkc().collect();
+
+    // Step 2: Strip HTML tags (including script/style content)
+    let stripped = strip_html(&nfkc);
+
+    // Step 3: Remove zero-width / invisible characters
+    let clean = remove_invisible_chars(&stripped);
+
+    // Step 4: Replace confusable characters in mixed-script words.
+    // Must be LAST because steps 2-3 may bring characters together
+    // (e.g., "ig<b>n</b>оre" or "ig\u{200B}nоre" → "ignоre" → "ignore").
+    replace_mixed_script_confusables(&clean)
+}
+
+// ---------------------------------------------------------------------------
+// L0 normalization evidence (metrics-producing path)
+// ---------------------------------------------------------------------------
+
+/// Content-free metrics describing a single L0 normalization. Numeric and
+/// boolean fields only: no offsets, tokens, ranges, or policy labels.
+///
+/// Counting semantics (see `normalize_with_evidence`):
+/// - `pre_*` measure the L0 input before NFKC.
+/// - `post_*` measure the final L0 output after confusable replacement,
+///   before role-marker neutralization.
+/// - `removed_invisible_count` counts characters removed by the display-path
+///   invisible strip, after NFKC and HTML stripping. Invisibles swallowed by
+///   the earlier HTML-strip stage are not counted here.
+/// - `confusable_replacement_count` counts exact character positions changed by
+///   the mixed-script confusable replacement stage.
+/// - `html_stripped` is true when the HTML-strip stage mutates the NFKC string.
+#[derive(Debug, Clone, PartialEq)]
+pub struct L0NormalizationEvidence {
+    pub pre_char_len: usize,
+    pub post_char_len: usize,
+    pub pre_byte_len: usize,
+    pub post_byte_len: usize,
+    pub removed_invisible_count: usize,
+    pub confusable_replacement_count: usize,
+    pub html_stripped: bool,
+}
+
+/// Normalize `input` with the same L0 stage order as `L0Normalizer::normalize`,
+/// while collecting content-free metrics about what each stage changed.
+///
+/// This reuses the existing private stage functions and the same `is_invisible`
+/// predicate used by `remove_invisible_chars`; it does not introduce a second
+/// invisible-character table.
+pub fn normalize_with_evidence(input: &str) -> (String, L0NormalizationEvidence) {
+    let pre_char_len = input.chars().count();
+    let pre_byte_len = input.len();
+
+    // Step 1: NFKC.
+    let nfkc: String = input.nfkc().collect();
+
+    // Step 2: HTML strip. `html_stripped` reflects whether the stage mutated the
+    // NFKC string (it does not prove well-formed HTML; the stripper also mutates
+    // stray angle-bracket spans).
+    let stripped = strip_html(&nfkc);
+    let html_stripped = stripped != nfkc;
+
+    // Step 3: invisible strip. Count by testing the post-HTML string with the
+    // same predicate the strip uses, so invisibles already removed by the HTML
+    // stage are not counted here.
+    let removed_invisible_count = stripped.chars().filter(|c| is_invisible(*c)).count();
+    let clean = remove_invisible_chars(&stripped);
+
+    // Step 4: mixed-script confusable replacement. The stage emits one output
+    // char per input char, so compare pre/post position-wise by `char`.
+    let replaced = replace_mixed_script_confusables(&clean);
+    let confusable_replacement_count = clean
+        .chars()
+        .zip(replaced.chars())
+        .filter(|(a, b)| a != b)
+        .count();
+
+    let post_char_len = replaced.chars().count();
+    let post_byte_len = replaced.len();
+
+    let evidence = L0NormalizationEvidence {
+        pre_char_len,
+        post_char_len,
+        pre_byte_len,
+        post_byte_len,
+        removed_invisible_count,
+        confusable_replacement_count,
+        html_stripped,
+    };
+    (replaced, evidence)
+}
+
+/// Per-message L0 evidence: the per-string `L0NormalizationEvidence` plus the
+/// originating `message_index`. This is the normalize-local evidence type;
+/// engine maps it into `routing::L0Evidence` to avoid a `normalize -> routing`
+/// dependency.
+#[derive(Debug, Clone, PartialEq)]
+pub struct L0MessageEvidence {
+    pub message_index: usize,
+    pub evidence: L0NormalizationEvidence,
 }
 
 // ---------------------------------------------------------------------------
@@ -498,6 +593,49 @@ pub fn normalize_messages_with_spans(normalizer: &dyn Normalizer, messages: &mut
             msg.content = normalizer.normalize(&msg.content);
         }
     }
+}
+
+/// Evidence-producing counterpart to `normalize_messages_with_spans`.
+///
+/// Keeps the exact same per-message sequence (normalize the full content, and
+/// call `remap_trust_spans` against the provided normalizer) so span offsets
+/// remain valid for `neutralize_role_markers` and downstream span-aware logic.
+/// Additionally derives content-free `L0NormalizationEvidence` for each message
+/// from the original content via `normalize_with_evidence`.
+///
+/// The normalized content and evidence counts come from the concrete L0 stage
+/// core. A debug assertion checks that the injected normalizer agrees, keeping
+/// future normalizer divergence visible while avoiding a second full
+/// normalization pass on the request hot path.
+pub fn normalize_messages_with_spans_and_evidence(
+    normalizer: &dyn Normalizer,
+    messages: &mut [Message],
+) -> Vec<L0MessageEvidence> {
+    let mut evidence = Vec::with_capacity(messages.len());
+    for (message_index, msg) in messages.iter_mut().enumerate() {
+        let original = msg.content.clone();
+        // Derive evidence and normalized content from the pre-normalization
+        // content in one pass. `remap_trust_spans` below still uses
+        // `normalizer.normalize` for its per-prefix calls.
+        let (normalized, ev) = normalize_with_evidence(&original);
+        debug_assert_eq!(
+            normalized,
+            normalizer.normalize(&original),
+            "L0 evidence helper must agree with the injected normalizer"
+        );
+        evidence.push(L0MessageEvidence {
+            message_index,
+            evidence: ev,
+        });
+
+        if !msg.trust_spans.is_empty() {
+            msg.content = normalized;
+            remap_trust_spans(normalizer, &original, &mut msg.trust_spans);
+        } else {
+            msg.content = normalized;
+        }
+    }
+    evidence
 }
 
 // ---------------------------------------------------------------------------
@@ -1346,6 +1484,91 @@ mod tests {
         let twice = normalize_for_comparison(&once);
         assert_eq!(once, twice);
         assert_eq!(once, "ab");
+    }
+
+    // -------------------------------------------------------------------
+    // 10b. L0 normalization evidence
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn normalize_with_evidence_matches_normalize_output() {
+        let n = normalizer();
+        let input = "<b>ig\u{200B}n\u{043E}re</b>";
+        let (out, _ev) = normalize_with_evidence(input);
+        assert_eq!(out, n.normalize(input));
+    }
+
+    #[test]
+    fn normalize_with_evidence_counts_invisible_removed() {
+        // One legacy invisible (ZWS) and one CHANGE 1 code point (U+E0080).
+        let (out, ev) = normalize_with_evidence("ig\u{200B}n\u{E0080}ore");
+        assert_eq!(out, "ignore");
+        assert_eq!(ev.removed_invisible_count, 2);
+        assert!(!ev.html_stripped);
+        assert_eq!(ev.confusable_replacement_count, 0);
+    }
+
+    #[test]
+    fn normalize_with_evidence_does_not_count_comparison_only() {
+        // U+034F (CGJ) survives display normalization and is not counted.
+        let (out, ev) = normalize_with_evidence("a\u{034F}b");
+        assert_eq!(out, "a\u{034F}b");
+        assert_eq!(ev.removed_invisible_count, 0);
+    }
+
+    #[test]
+    fn normalize_with_evidence_reports_html_and_confusable() {
+        // HTML stage mutates, and a mixed Cyrillic/Latin word is repaired.
+        let (out, ev) = normalize_with_evidence("<b>ign\u{043E}re</b>");
+        assert_eq!(out, "ignore");
+        assert!(ev.html_stripped);
+        // Only the Cyrillic 'о' position changes.
+        assert_eq!(ev.confusable_replacement_count, 1);
+        assert_eq!(ev.removed_invisible_count, 0);
+    }
+
+    #[test]
+    fn normalize_with_evidence_html_stage_mutation_semantics() {
+        // Stray angle-bracket span containing an invisible: the invisible is
+        // swallowed by the HTML strip, so it is NOT counted as removed_invisible.
+        let (out, ev) = normalize_with_evidence("a<\u{200B}x>c");
+        assert_eq!(out, "ac");
+        assert!(ev.html_stripped);
+        assert_eq!(ev.removed_invisible_count, 0);
+    }
+
+    #[test]
+    fn normalize_with_evidence_lengths() {
+        // Fullwidth A,B (3 bytes each) -> ASCII (1 byte each).
+        let (out, ev) = normalize_with_evidence("\u{FF21}\u{FF22}");
+        assert_eq!(out, "AB");
+        assert_eq!(ev.pre_char_len, 2);
+        assert_eq!(ev.post_char_len, 2);
+        assert_eq!(ev.pre_byte_len, 6);
+        assert_eq!(ev.post_byte_len, 2);
+    }
+
+    #[test]
+    fn normalize_messages_with_spans_and_evidence_remaps_and_reports() {
+        let n = normalizer();
+        // Trusted message with an untrusted span containing an invisible char.
+        let mut msg = Message::new(Role::User, "he\u{200B}llo data");
+        // "llo data" starts after "he"(2) + ZWS(3) = byte 5.
+        msg.trust_spans
+            .push(crate::trust::TrustSpan::untrusted(5, msg.content.len(), "rag"));
+
+        let mut messages = vec![msg];
+        let evidence = normalize_messages_with_spans_and_evidence(&n, &mut messages);
+
+        // Content normalized and spans remapped against the same normalizer.
+        assert_eq!(messages[0].content, "hello data");
+        assert_eq!(messages[0].trust_spans[0].start, 2);
+        assert_eq!(messages[0].trust_spans[0].end, "hello data".len());
+
+        // Evidence produced for the message.
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence[0].message_index, 0);
+        assert_eq!(evidence[0].evidence.removed_invisible_count, 1);
     }
 
     // -------------------------------------------------------------------

--- a/parapet/src/routing/mod.rs
+++ b/parapet/src/routing/mod.rs
@@ -155,10 +155,11 @@ impl<'a> RoutingEvidenceContext<'a> {
 ///
 /// Fixed numeric and boolean telemetry only: no message content, no byte
 /// ranges, no character offsets, no matched tokens, no policy vocabulary.
-/// Counts are bounded per message and intended to be derived deterministically
-/// from the L0 sanitize pass. Engine population is not wired yet; the field
-/// is reserved on `RoutingEvidenceContext` for future routing-evidence
-/// consumers and must not gate enforcement decisions in its first wire-up.
+/// Counts are bounded per message and derived deterministically from the L0
+/// sanitize pass. Engine population is wired: when L0 runs in `sanitize` mode,
+/// `engine::process_request` collects one `L0Evidence` per message and passes
+/// `Some(&[L0Evidence])` into `RoutingEvidenceContext`. This evidence is for
+/// routing consumers only and must not gate enforcement decisions.
 #[derive(Debug, Clone, PartialEq)]
 pub struct L0Evidence {
     pub message_index: usize,

--- a/strategy/l0_evidence_population_spec.md
+++ b/strategy/l0_evidence_population_spec.md
@@ -1,0 +1,184 @@
+# L0 evidence population spec
+
+Date: 2026-06-27
+Owner: routing
+Status: accepted and implemented
+
+## Goal
+
+Wire `L0Evidence` population for the existing routing evidence context without
+changing enforcement behavior. The first slice should make
+`removed_invisible_count` observable to routing consumers while preserving the
+current L0 sanitize semantics, including trust-span remapping.
+
+## Current State
+
+- `routing::L0Evidence` already exists and is deliberately content-free:
+  numeric and boolean fields only, no offsets, tokens, ranges, or policy labels.
+- `RoutingEvidenceContext::new` accepts `l0: Option<&[L0Evidence]>`, but
+  `engine::process_request` currently passes `None`.
+- `L0Normalizer::normalize` already performs:
+  `NFKC -> strip_html -> remove_invisible_chars -> replace_mixed_script_confusables`.
+- The recent Default_Ignorable work extended `is_invisible`; those display-path
+  removals must count the same way as the older invisible set.
+- `normalize_for_comparison` has an additional comparison-only strip for
+  `U+034F`, `U+17B4`, and `U+17B5`; it emits no evidence and is not part of this
+  slice.
+
+## Contract
+
+Add a metrics-producing L0 sanitize helper that reuses the same private stage
+functions as `L0Normalizer::normalize`:
+
+```rust
+pub struct L0NormalizationEvidence {
+    pub pre_char_len: usize,
+    pub post_char_len: usize,
+    pub pre_byte_len: usize,
+    pub post_byte_len: usize,
+    pub removed_invisible_count: usize,
+    pub confusable_replacement_count: usize,
+    pub html_stripped: bool,
+}
+
+pub fn normalize_with_evidence(input: &str) -> (String, L0NormalizationEvidence)
+```
+
+For whole-message normalization, a message helper may wrap this per-string
+evidence with `message_index`; use a distinct wrapper name only if it adds that
+message-local field.
+
+The ordinary `Normalizer::normalize` hot path must not do evidence work. Use a
+private normalization core for the stage order, and have both
+`L0Normalizer::normalize` and `normalize_with_evidence` call that core. This is
+important because `remap_trust_spans` calls `normalizer.normalize(prefix)` for
+span-boundary prefixes; evidence allocation and counting should not run for
+those internal prefix normalizations.
+
+The evidence-producing message helper should also avoid a second full-message
+L0 pass. It may reuse the normalized output returned by `normalize_with_evidence`
+as the message content, then call `remap_trust_spans` with the injected
+normalizer for span-prefix remapping. Add a debug-only agreement check between
+the concrete L0 output and the injected normalizer so future normalizer
+divergence is caught in tests/debug builds.
+
+The helper should not introduce a second invisible-character table. It should
+derive `removed_invisible_count` by applying the existing L0 stage order and
+testing characters with the same `is_invisible` predicate used by
+`remove_invisible_chars`.
+
+Counting semantics:
+
+- `pre_*` count the L0 input string before NFKC. This is after request parsing,
+  trust-header parsing, and trust assignment, not raw request bytes.
+- `post_*` count the final L0 normalized output after confusable replacement,
+  before role-marker neutralization.
+- `removed_invisible_count` counts characters removed by the display-path
+  invisible strip after NFKC and HTML stripping.
+- Invisible characters inside text swallowed by the HTML-strip stage are not
+  counted in `removed_invisible_count`; they are removed as part of the earlier
+  HTML-strip mutation, not by the invisible-strip stage.
+- `html_stripped` is true when the HTML-strip stage mutates the NFKC string. It
+  means the stage changed content; it does not prove well-formed HTML was
+  present because the current stripper also mutates stray angle-bracket spans.
+- `confusable_replacement_count` counts exact character positions changed by the
+  final mixed-script confusable replacement stage. The current replacement stage
+  emits one output char for each input char, so compare the pre-confusable and
+  post-confusable strings position-wise by `char`.
+- `role_marker_neutralized_count` remains populated from
+  `neutralize_role_markers`. Role-marker neutralization uses equal-length space
+  replacement and is represented only by this field, not by `post_*`.
+
+Engine behavior:
+
+- When L0 mode is `sanitize`, preserve the existing
+  `normalize_messages_with_spans` behavior. The evidence-producing path must
+  normalize message content in the same L0 stage order and still call
+  `remap_trust_spans` so span offsets remain valid for
+  `neutralize_role_markers` and downstream span-aware logic.
+- Collect one `routing::L0Evidence` per message and pass
+  `Some(&l0_evidence)` into `RoutingEvidenceContext::new`.
+- When L0 is absent or not in `sanitize` mode, pass `None`.
+- First integration must not change verdicts, blocking, thresholds, or default
+  router behavior.
+
+## Non-goals
+
+- Do not count comparison-only removals from `normalize_for_comparison`.
+- Do not expose raw content, spans, offsets, matched tokens, or codepoint lists
+  through routing evidence.
+- Do not add an enforcement dependency on L0 evidence.
+- Do not replace `normalize_messages_with_spans` with a message-only normalize
+  helper that drops span remapping.
+- Do not expose private L0 stage functions to engine just to compose evidence
+  there.
+
+## Implementation Sketch
+
+1. In `normalize/mod.rs`, add `L0NormalizationEvidence` and
+   `normalize_with_evidence`.
+2. Factor the existing stage order into private helpers so
+   `L0Normalizer::normalize` stays cheap while `normalize_with_evidence`
+   performs the extra counts. Do not make `normalize` delegate through the
+   evidence-producing API.
+3. Add a span-preserving message-slice helper, likely:
+   `normalize_messages_with_spans_and_evidence(...) -> Vec<L0MessageEvidence>`.
+   If `L0MessageEvidence` is introduced, it should be the per-string
+   `L0NormalizationEvidence` plus `message_index`, not a second evidence
+   vocabulary.
+   This helper must keep the current `normalize_messages_with_spans` sequence:
+   normalize the full message content once, reuse the normalized output from
+   `normalize_with_evidence`, and call `remap_trust_spans` against the same
+   normalizer. Return a normalize-local evidence type; engine maps it into
+   `routing::L0Evidence` to avoid a `normalize -> routing` dependency.
+4. In `engine::process_request`, replace the L0 sanitize call with the
+   span-preserving evidence helper and merge in the role-marker neutralization
+   count by `message_index`.
+5. Bind the collected `Vec<routing::L0Evidence>` in a scope that outlives
+   `RoutingEvidenceContext::new`, then pass `Some(&l0_evidence)` into the
+   context.
+
+## Tests
+
+Targeted Rust tests are enough for this slice:
+
+- `normalize_with_evidence_counts_invisible_removed`: includes at least one old
+  invisible and one recent CHANGE 1 code point such as `U+E0080`; expected count
+  reflects both.
+- `normalize_with_evidence_does_not_count_comparison_only`: `U+034F` survives
+  display normalization and does not increment `removed_invisible_count`.
+- `normalize_with_evidence_reports_html_and_confusable`: HTML stage and mixed
+  Cyrillic/Latin confusable replacement are reflected without exposing content.
+- `normalize_with_evidence_html_stage_mutation_semantics`: stray angle-bracket
+  stripping sets `html_stripped`, and an invisible inside a stripped tag is not
+  counted by `removed_invisible_count`.
+- Engine or routing-context test proving L0 sanitize passes `Some(&[L0Evidence])`
+  to a test router, and non-sanitize/no-L0 passes `None`.
+- Span regression: a trusted message with an untrusted span containing an
+  invisible character still has remapped spans after evidence-producing
+  normalization, and the same message produces L0 evidence.
+- Role-marker regression: role-marker neutralization increments
+  `role_marker_neutralized_count` but does not change the `post_*` L0 lengths.
+- Existing normalize tests continue to pass.
+
+Suggested validation:
+
+```bash
+cd parapet
+cargo test normalize --lib
+cargo test routing --lib
+cargo test engine --lib
+git diff --check
+python3 scripts/check_no_data_commit.py --all
+```
+
+Full `cargo test` is preferred before merge if the local environment allows it.
+
+## Review Questions
+
+1. `removed_invisible_count` should count at the actual invisible-strip stage
+   after NFKC and HTML stripping. Keep the name and document the stage semantics.
+2. `confusable_replacement_count` should be exact. The current confusable stage
+   is one output char per input char, so position-wise char comparison is enough.
+3. The helper should live in `normalize`; engine should not compose private L0
+   stages directly.


### PR DESCRIPTION
  ## Summary
  - add L0 normalize evidence helpers and span-preserving message evidence collection
  - wire L0 sanitize evidence into RoutingEvidenceContext for routing consumers
  - cover sanitize/non-sanitize routing behavior plus invisible, HTML, confusable, span,
  and role-marker evidence semantics

  ## Validation
  - cargo test normalize --lib
  - cargo test routing --lib
  - cargo test engine --lib
  - cargo test --lib
  - git diff --check
  - python3 scripts/check_no_data_commit.py --all

  Commit: f977bc5 Populate L0 evidence for routing.